### PR TITLE
Changed hook for tinymce components initialization

### DIFF
--- a/better-font-awesome-library.php
+++ b/better-font-awesome-library.php
@@ -287,7 +287,7 @@ class Better_Font_Awesome_Library {
 		// Load TinyMCE functionality.
 		if ( $this->args['load_tinymce_plugin'] ) {
 		
-			add_action( 'admin_head', array( $this, 'add_tinymce_components' ) );
+			add_action( 'admin_init', array( $this, 'add_tinymce_components' ) );
 			add_action( 'admin_head', array( $this, 'output_admin_head_variables' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'register_custom_admin_css' ), 15 );
 


### PR DESCRIPTION
This allows for better compatibility with other plugins. See https://wordpress.org/support/topic/conflict-with-black-studio-tinymce-widget-siteorigin-page-builder?replies=1#post-6145220
