### PR TITLE
Prepare BFAL 2.1.0-rc.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,5 +13,6 @@ composer.lock export-ignore
 Gruntfile.js export-ignore
 package.json export-ignore
 package-lock.json export-ignore
+RELEASING.md export-ignore
 runtime-assets export-ignore
 scripts export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## 2.1.0-rc.1
+
+- Added a validated Font Awesome Free 5.x provider and release-record contract. Normal frontend, admin, editor, REST, and other request paths resolve only local provider, transient, or bundled fallback data.
+- Restricted remote metadata transport to the explicit asynchronous worker operation. Requests verify TLS, reject unsafe URLs and redirects, enforce bounded time and response size, and expose sanitized failures.
+- Added full release-record, asset, SRI, and fallback checksum validation before metadata is adopted.
+- Preserved the `bfa-release-data` transient shape and added deterministic provider, transient, and checksummed fallback precedence. Consumers continue to own durable storage, freshness, scheduling, locking, and retries.
+- Preserved PHP 7.4 support, existing public methods and filters, and the first-caller singleton ownership contract. Later initialization arguments remain ignored.
+
+To test the candidate after its tag is published:
+
+```console
+composer require mickey-kay/better-font-awesome-library:2.1.0-rc.1
+```
+
+To roll back to the previous stable release:
+
+```console
+composer require mickey-kay/better-font-awesome-library:2.0.3 --with-all-dependencies
+```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Better Font Awesome Library
 1. [Introduction](https://github.com/MickeyKay/better-font-awesome-library#introduction)
 1. [Features](https://github.com/MickeyKay/better-font-awesome-library#features)
 1. [Installation](https://github.com/MickeyKay/better-font-awesome-library#installation)
+1. [Release candidate and rollback](https://github.com/MickeyKay/better-font-awesome-library#release-candidate-and-rollback)
+1. [Changelog](https://github.com/MickeyKay/better-font-awesome-library/blob/master/CHANGELOG.md)
 1. [Usage](https://github.com/MickeyKay/better-font-awesome-library#usage)
 1. [Metadata lifecycle](https://github.com/MickeyKay/better-font-awesome-library#metadata-lifecycle)
 1. [Compatibility notes](https://github.com/MickeyKay/better-font-awesome-library#compatibility-notes)
@@ -41,6 +43,22 @@ git clone https://github.com/MickeyKay/better-font-awesome-library.git
 cd better-font-awesome-library
 npm run build
 ```
+
+## Release candidate and rollback ##
+
+After the `2.1.0-rc.1` tag is published, Composer users can test this exact candidate with an explicit stability-qualified constraint:
+
+```
+composer require mickey-kay/better-font-awesome-library:2.1.0-rc.1
+```
+
+To roll back, restore the last stable BFAL release and redeploy the resulting lockfile:
+
+```
+composer require mickey-kay/better-font-awesome-library:2.0.3 --with-all-dependencies
+```
+
+BFAL follows versions published from repository tags. The release candidate does not change the first-caller singleton ownership contract or introduce a post-construction registration API.
 
 ## Usage ##
 1. Copy the /better-font-awesome-library folder into your project.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,61 @@
+# Releasing BFAL
+
+BFAL versions are published from repository tags and discovered automatically by Packagist. Do not add a `version` field to `composer.json`.
+
+## Prepare and verify
+
+Set the intended version and start from a clean checkout of its candidate commit:
+
+```console
+RELEASE_VERSION=2.1.0-rc.1
+git status --short
+composer install --no-interaction --prefer-dist
+composer validate --strict
+composer audit
+composer check
+npm run build
+npm run audit:runtime-assets
+git diff --exit-code
+```
+
+Confirm that `Better_Font_Awesome_Library::VERSION`, both npm manifests, both npm lockfile root records, the compatibility test, and the changelog use the same release version. `composer.json` intentionally has no version field because Composer derives the package version from the tag.
+
+## Build the production archive
+
+Create the archive only from the intended tag. The tracked `.gitattributes` rules exclude tests, agent files, development configuration, development locks, build sources, and release tooling. Runtime Composer dependencies belong in `composer.json`; BFAL currently has no runtime Composer dependencies and the archive must not contain `vendor`.
+
+```console
+RELEASE_VERSION=2.1.0-rc.1
+ARTIFACT_PATH="better-font-awesome-library-${RELEASE_VERSION}.zip"
+git archive \
+  --format=zip \
+  --prefix="better-font-awesome-library-${RELEASE_VERSION}/" \
+  --output="$ARTIFACT_PATH" \
+  "$RELEASE_VERSION"
+shasum -a 256 "$ARTIFACT_PATH"
+unzip -l "$ARTIFACT_PATH"
+```
+
+Running the same command twice from clean checkouts of the same tag must produce identical SHA-256 checksums. Manually inspect the archive before publication.
+
+## Publish
+
+Recent stable BFAL releases use prefix-free, lightweight numeric tags. Release candidates also use a prefix-free tag, with `2.1.0-rc.1` as the first 2.1.0 candidate.
+
+After the release-preparation pull request is approved and merged:
+
+1. Re-run the complete hosted PHP 7.4 through 8.4 matrix on the exact merge commit.
+2. Create and push the lightweight `2.1.0-rc.1` tag on that verified commit.
+3. Rebuild and inspect the archive from the tag, then record its SHA-256 checksum.
+4. Create a prerelease GitHub release and attach the verified archive.
+5. Confirm that Packagist discovers `2.1.0-rc.1` and that Composer installs the expected tag and dist contents.
+
+Do not publish if the tag, internal version, changelog, archive root directory, or checksum record disagree.
+
+## Roll back
+
+BFAL 2.0.3 is the rollback release. Restore it in the consuming project and redeploy the updated lockfile:
+
+```console
+composer require mickey-kay/better-font-awesome-library:2.0.3 --with-all-dependencies
+```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,21 +22,30 @@ Confirm that `Better_Font_Awesome_Library::VERSION`, both npm manifests, both np
 
 ## Build the production archive
 
-Create the archive only from the intended tag. The tracked `.gitattributes` rules exclude tests, agent files, development configuration, development locks, build sources, and release tooling. Runtime Composer dependencies belong in `composer.json`; BFAL currently has no runtime Composer dependencies and the archive must not contain `vendor`.
+Create both verification archives only from the unpushed local tag. The tracked `.gitattributes` rules exclude tests, agent files, development configuration, development locks, build sources, and release tooling. Runtime Composer dependencies belong in `composer.json`; BFAL currently has no runtime Composer dependencies and the archive must not contain `vendor`.
 
 ```console
 RELEASE_VERSION=2.1.0-rc.1
 ARTIFACT_PATH="better-font-awesome-library-${RELEASE_VERSION}.zip"
+VERIFICATION_ARTIFACT_PATH="better-font-awesome-library-${RELEASE_VERSION}-verification.zip"
+CHECKSUM_PATH="better-font-awesome-library-${RELEASE_VERSION}.sha256"
 git archive \
   --format=zip \
   --prefix="better-font-awesome-library-${RELEASE_VERSION}/" \
   --output="$ARTIFACT_PATH" \
   "$RELEASE_VERSION"
-shasum -a 256 "$ARTIFACT_PATH"
+git archive \
+  --format=zip \
+  --prefix="better-font-awesome-library-${RELEASE_VERSION}/" \
+  --output="$VERIFICATION_ARTIFACT_PATH" \
+  "$RELEASE_VERSION"
+cmp "$ARTIFACT_PATH" "$VERIFICATION_ARTIFACT_PATH"
+shasum -a 256 "$ARTIFACT_PATH" > "$CHECKSUM_PATH"
+cat "$CHECKSUM_PATH"
 unzip -l "$ARTIFACT_PATH"
 ```
 
-Running the same command twice from clean checkouts of the same tag must produce identical SHA-256 checksums. Manually inspect the archive before publication.
+The two archives must be byte-identical. Before publication, manually confirm the archive contains exactly 18 production files under the single `better-font-awesome-library-2.1.0-rc.1/` root directory. Confirm every required runtime file, the internal version surfaces, and the final SHA-256 checksum. Confirm tests, agent files, development dependencies, build sources, `node_modules`, and `vendor` are absent.
 
 ## Publish
 
@@ -44,13 +53,22 @@ Recent stable BFAL releases use prefix-free, lightweight numeric tags. Release c
 
 After the release-preparation pull request is approved and merged:
 
-1. Re-run the complete hosted PHP 7.4 through 8.4 matrix on the exact merge commit.
-2. Create and push the lightweight `2.1.0-rc.1` tag on that verified commit.
-3. Rebuild and inspect the archive from the tag, then record its SHA-256 checksum.
-4. Create a prerelease GitHub release and attach the verified archive.
-5. Confirm that Packagist discovers `2.1.0-rc.1` and that Composer installs the expected tag and dist contents.
+1. Confirm the intended merged release commit and that the complete hosted PHP 7.4 through 8.4 and packaging matrix passed on that exact commit.
+2. Create the lightweight `2.1.0-rc.1` tag locally on the intended merge commit. Do not push it.
+3. Build the production archive twice from that exact unpushed local tag using the commands above.
+4. Confirm byte identity, all archive contents and exclusions, the single exact root directory, every version surface, and the final SHA-256 checksum. Create the `.sha256` file from the verified ZIP.
+5. Confirm the locally tagged commit is exactly the intended merge commit:
 
-Do not publish if the tag, internal version, changelog, archive root directory, or checksum record disagree.
+   ```console
+   test "$(git rev-parse '2.1.0-rc.1^{commit}')" = "$(git rev-parse origin/master)"
+   ```
+
+6. Only after every local-tag verification passes, push the tag. Pushing the tag is the publication boundary because Packagist may discover it immediately. Checks performed after this push confirm publication state but cannot prevent publication.
+7. Immediately create the GitHub prerelease and attach both the verified ZIP and its `.sha256` checksum file.
+8. Include the exact SHA-256 checksum directly in the GitHub prerelease notes as well as in the attached checksum file.
+9. Confirm that Packagist discovers `2.1.0-rc.1` with RC stability, points to the exact tagged merge commit, and that Composer installs the expected distribution contents.
+
+Do not push the tag if the tagged commit, internal version, changelog, archive contents, archive root directory, byte comparison, or checksum record disagree.
 
 ## Roll back
 

--- a/better-font-awesome-library.php
+++ b/better-font-awesome-library.php
@@ -47,7 +47,7 @@ class Better_Font_Awesome_Library {
 	 *
 	 * @var    string
 	 */
-	const VERSION = '2.0.3';
+	const VERSION = '2.1.0-rc.1';
 
 	/**
 	 * Font awesome GraphQL url.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-font-awesome-library",
-  "version": "2.0.3",
+  "version": "2.1.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-font-awesome-library",
-      "version": "2.0.3",
+      "version": "2.1.0-rc.1",
       "license": "GPL-2.0",
       "devDependencies": {
         "fontawesome-iconpicker": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-font-awesome-library",
   "description": "Better Font Awesome Library",
-  "version": "2.0.3",
+  "version": "2.1.0-rc.1",
   "main": " ",
   "devDependencies": {
     "fontawesome-iconpicker": "3.2.0",

--- a/runtime-assets/package-lock.json
+++ b/runtime-assets/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-font-awesome-library-runtime-assets",
-  "version": "2.0.3",
+  "version": "2.1.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-font-awesome-library-runtime-assets",
-      "version": "2.0.3",
+      "version": "2.1.0-rc.1",
       "dependencies": {
         "fontawesome-iconpicker": "3.2.0"
       }

--- a/runtime-assets/package.json
+++ b/runtime-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-font-awesome-library-runtime-assets",
-  "version": "2.0.3",
+  "version": "2.1.0-rc.1",
   "private": true,
   "description": "Audit manifest for third-party browser source copied into BFAL release archives.",
   "dependencies": {

--- a/tests/PublicCompatibilityTest.php
+++ b/tests/PublicCompatibilityTest.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/BfalTestCase.php';
 class PublicCompatibilityTest extends BfalTestCase {
 	public function test_public_constants_are_preserved() {
 		$this->assertSame( 'bfa', Better_Font_Awesome_Library::SLUG );
-		$this->assertSame( '2.0.3', Better_Font_Awesome_Library::VERSION );
+		$this->assertSame( '2.1.0-rc.1', Better_Font_Awesome_Library::VERSION );
 		$this->assertSame( 'https://api.fontawesome.com', Better_Font_Awesome_Library::FONT_AWESOME_API_BASE_URL );
 		$this->assertSame( 'https://use.fontawesome.com/releases', Better_Font_Awesome_Library::FONT_AWESOME_CDN_BASE_URL );
 		$this->assertSame( 'inc/fallback-release-data.json', Better_Font_Awesome_Library::FALLBACK_RELEASE_DATA_PATH );


### PR DESCRIPTION
## Summary

- set every public BFAL version surface to `2.1.0-rc.1`
- add candidate changelog, Composer installation, rollback, and maintainer release instructions
- preserve the reviewed metadata architecture and all runtime behavior except the public library version constant
- exclude maintainer release tooling from production archives

## Validation

- PHPUnit: 86 tests, 390 assertions
- PHPCS and PHPStan: passed
- Composer validate `--strict` and Composer audit: passed
- tracked browser asset rebuild: reproducible with no diff
- shipped runtime asset audit: zero advisories
- clean-state production archive builds: byte-identical
- candidate archive SHA-256: `c8ad940a6d21ed0f716d8bc382f9fc9c35f0c1e71204715d77083bb578d20128`
- archive audit: 18 production files, no tests, agent files, build sources, development dependencies, `node_modules`, or `vendor`
- BFA PR #52 exact-candidate single-site integration: 74 tests, 17,642 assertions
- BFA PR #52 exact-candidate multisite integration: 74 tests, 17,661 assertions

## Release gate

This is a draft release-preparation PR. Do not tag, publish, create a GitHub release, or update Packagist from this branch. After approval and merge, rerun the hosted matrix on the exact merge commit, create the lightweight `2.1.0-rc.1` tag, rebuild and inspect the archive from that tag, publish it as a GitHub prerelease asset, and verify Packagist discovery.
