### PR TITLE
Fix Block Editor iframe Font Awesome stylesheet failures

### DIFF
--- a/better-font-awesome-library.php
+++ b/better-font-awesome-library.php
@@ -962,6 +962,13 @@ class Better_Font_Awesome_Library {
 	 * Register and enqueue Font Awesome CSS.
 	 */
 	public function register_font_awesome_css() {
+		if ( is_admin() && function_exists( 'get_current_screen' ) ) {
+			$screen = get_current_screen();
+			if ( $screen && is_callable( array( $screen, 'is_block_editor' ) ) && $screen->is_block_editor() ) {
+				return;
+			}
+		}
+
 		$stylesheet_url = $this->get_stylesheet_url();
 		if ( '' === $stylesheet_url ) {
 			return;
@@ -1047,18 +1054,36 @@ class Better_Font_Awesome_Library {
 	 * @since  1.0.0
 	 */
 	public function add_editor_styles() {
+		$stylesheets    = array();
 		$stylesheet_url = $this->get_stylesheet_url();
 		if ( '' !== $stylesheet_url ) {
-			add_editor_style( $stylesheet_url );
+			$stylesheets[] = $stylesheet_url;
 		}
 
 		// Conditionally include the Font Awesome v4 CSS shim.
 		if ( $this->args['include_v4_shim'] ) {
 			$v4_shim_url = $this->get_stylesheet_url_v4_shim();
 			if ( '' !== $v4_shim_url ) {
-				add_editor_style( $v4_shim_url );
+				$stylesheets[] = $v4_shim_url;
 			}
 		}
+
+		if ( empty( $stylesheets ) ) {
+			return;
+		}
+
+		add_filter(
+			'mce_css',
+			static function ( $mce_css ) use ( $stylesheets ) {
+				$mce_css         = trim( (string) $mce_css, ' ,' );
+				$filtered_styles = $stylesheets;
+				if ( '' !== $mce_css ) {
+					$filtered_styles = array_merge( array( $mce_css ), $filtered_styles );
+				}
+
+				return implode( ',', $filtered_styles );
+			}
+		);
 	}
 
 	/**

--- a/better-font-awesome-library.php
+++ b/better-font-awesome-library.php
@@ -285,6 +285,7 @@ class Better_Font_Awesome_Library {
 		 * Use priority 15 to make sure styles/scripts load after other plugins.
 		 */
 		if ( $this->args['load_admin_styles'] || $this->args['load_tinymce_plugin'] ) {
+			add_action( 'admin_enqueue_scripts', array( $this, 'disable_block_editor_font_awesome_css' ), 14 );
 			add_action( 'admin_enqueue_scripts', array( $this, 'register_font_awesome_css' ), 15 );
 		}
 
@@ -959,16 +960,29 @@ class Better_Font_Awesome_Library {
 	}
 
 	/**
+	 * Disable BFAL's automatic Font Awesome enqueue on Block Editor screens.
+	 *
+	 * This is an internal lifecycle callback for the admin enqueue hook, not an
+	 * integration API. Direct calls to register_font_awesome_css() are unchanged.
+	 *
+	 * @since  2.1.0
+	 * @internal
+	 */
+	public function disable_block_editor_font_awesome_css() {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return;
+		}
+
+		$screen = get_current_screen();
+		if ( $screen && is_callable( array( $screen, 'is_block_editor' ) ) && $screen->is_block_editor() ) {
+			remove_action( 'admin_enqueue_scripts', array( $this, 'register_font_awesome_css' ), 15 );
+		}
+	}
+
+	/**
 	 * Register and enqueue Font Awesome CSS.
 	 */
 	public function register_font_awesome_css() {
-		if ( is_admin() && function_exists( 'get_current_screen' ) ) {
-			$screen = get_current_screen();
-			if ( $screen && is_callable( array( $screen, 'is_block_editor' ) ) && $screen->is_block_editor() ) {
-				return;
-			}
-		}
-
 		$stylesheet_url = $this->get_stylesheet_url();
 		if ( '' === $stylesheet_url ) {
 			return;
@@ -1054,36 +1068,18 @@ class Better_Font_Awesome_Library {
 	 * @since  1.0.0
 	 */
 	public function add_editor_styles() {
-		$stylesheets    = array();
 		$stylesheet_url = $this->get_stylesheet_url();
 		if ( '' !== $stylesheet_url ) {
-			$stylesheets[] = $stylesheet_url;
+			add_editor_style( $stylesheet_url );
 		}
 
 		// Conditionally include the Font Awesome v4 CSS shim.
 		if ( $this->args['include_v4_shim'] ) {
 			$v4_shim_url = $this->get_stylesheet_url_v4_shim();
 			if ( '' !== $v4_shim_url ) {
-				$stylesheets[] = $v4_shim_url;
+				add_editor_style( $v4_shim_url );
 			}
 		}
-
-		if ( empty( $stylesheets ) ) {
-			return;
-		}
-
-		add_filter(
-			'mce_css',
-			static function ( $mce_css ) use ( $stylesheets ) {
-				$mce_css         = trim( (string) $mce_css, ' ,' );
-				$filtered_styles = $stylesheets;
-				if ( '' !== $mce_css ) {
-					$filtered_styles = array_merge( array( $mce_css ), $filtered_styles );
-				}
-
-				return implode( ',', $filtered_styles );
-			}
-		);
 	}
 
 	/**

--- a/tests/EditorStylesTest.php
+++ b/tests/EditorStylesTest.php
@@ -1,0 +1,46 @@
+<?php
+
+require_once __DIR__ . '/BfalTestCase.php';
+
+class EditorStylesTest extends BfalTestCase {
+	public function test_font_awesome_admin_styles_are_not_enqueued_on_block_editor_screens() {
+		$this->get_instance( array( 'include_v4_shim' => true ) );
+		$GLOBALS['bfa_test_is_admin']        = true;
+		$GLOBALS['bfa_test_is_block_editor'] = true;
+
+		do_action( 'admin_enqueue_scripts', 'post.php' );
+
+		$this->assertArrayNotHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_enqueued_styles'] );
+		$this->assertArrayNotHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_enqueued_styles'] );
+	}
+
+	public function test_frontend_styles_are_unchanged_for_block_editor_requests() {
+		$this->get_instance( array( 'include_v4_shim' => true ) );
+		$GLOBALS['bfa_test_is_admin']        = false;
+		$GLOBALS['bfa_test_is_block_editor'] = true;
+
+		do_action( 'wp_enqueue_scripts' );
+
+		$this->assertArrayHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_enqueued_styles'] );
+		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_enqueued_styles'] );
+	}
+
+	public function test_font_awesome_editor_styles_are_scoped_to_tinymce() {
+		$this->get_instance( array( 'include_v4_shim' => true ) );
+
+		$this->assertSame(
+			array(),
+			$GLOBALS['bfa_test_editor_styles'],
+			'Font Awesome styles must not be registered as global editor styles.'
+		);
+		$this->assertArrayHasKey( 'mce_css', $GLOBALS['bfa_test_filter_callbacks'] );
+		$this->assertSame(
+			'wp-content.css,https://use.fontawesome.com/releases/v5.15.4/css/all.css,https://use.fontawesome.com/releases/v5.15.4/css/v4-shims.css',
+			apply_filters( 'mce_css', 'wp-content.css' )
+		);
+		$this->assertSame(
+			'https://use.fontawesome.com/releases/v5.15.4/css/all.css,https://use.fontawesome.com/releases/v5.15.4/css/v4-shims.css',
+			apply_filters( 'mce_css', '' )
+		);
+	}
+}

--- a/tests/EditorStylesTest.php
+++ b/tests/EditorStylesTest.php
@@ -3,9 +3,8 @@
 require_once __DIR__ . '/BfalTestCase.php';
 
 class EditorStylesTest extends BfalTestCase {
-	public function test_font_awesome_admin_styles_are_not_enqueued_on_block_editor_screens() {
+	public function test_automatic_admin_enqueue_skips_block_editor_screens() {
 		$this->get_instance( array( 'include_v4_shim' => true ) );
-		$GLOBALS['bfa_test_is_admin']        = true;
 		$GLOBALS['bfa_test_is_block_editor'] = true;
 
 		do_action( 'admin_enqueue_scripts', 'post.php' );
@@ -14,9 +13,37 @@ class EditorStylesTest extends BfalTestCase {
 		$this->assertArrayNotHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_enqueued_styles'] );
 	}
 
-	public function test_frontend_styles_are_unchanged_for_block_editor_requests() {
+	public function test_direct_registration_remains_available_on_block_editor_screens() {
+		$library = $this->get_instance( array( 'include_v4_shim' => true ) );
+		$GLOBALS['bfa_test_is_block_editor'] = true;
+
+		$library->register_font_awesome_css();
+
+		$this->assertArrayHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_enqueued_styles'] );
+		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_enqueued_styles'] );
+	}
+
+	public function test_normal_admin_screen_retains_automatic_font_awesome_loading() {
 		$this->get_instance( array( 'include_v4_shim' => true ) );
-		$GLOBALS['bfa_test_is_admin']        = false;
+
+		do_action( 'admin_enqueue_scripts', 'plugins.php' );
+
+		$this->assertArrayHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_enqueued_styles'] );
+		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_enqueued_styles'] );
+	}
+
+	public function test_missing_current_screen_fails_open_without_errors() {
+		$this->get_instance( array( 'include_v4_shim' => true ) );
+		$GLOBALS['bfa_test_has_current_screen'] = false;
+
+		do_action( 'admin_enqueue_scripts', 'plugins.php' );
+
+		$this->assertArrayHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_enqueued_styles'] );
+		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_enqueued_styles'] );
+	}
+
+	public function test_frontend_automatic_loading_remains_unchanged() {
+		$this->get_instance( array( 'include_v4_shim' => true ) );
 		$GLOBALS['bfa_test_is_block_editor'] = true;
 
 		do_action( 'wp_enqueue_scripts' );
@@ -25,22 +52,40 @@ class EditorStylesTest extends BfalTestCase {
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_enqueued_styles'] );
 	}
 
-	public function test_font_awesome_editor_styles_are_scoped_to_tinymce() {
-		$this->get_instance( array( 'include_v4_shim' => true ) );
+	public function test_v4_shim_disabled_registers_only_the_main_stylesheet() {
+		$library = $this->get_instance( array( 'include_v4_shim' => false ) );
+
+		$library->register_font_awesome_css();
+
+		$this->assertArrayHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_enqueued_styles'] );
+		$this->assertArrayNotHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_enqueued_styles'] );
+	}
+
+	public function test_editor_styles_preserve_existing_entries_and_wordpress_deduplication() {
+		$GLOBALS['bfa_test_editor_styles'][] = 'theme-editor.css';
+		$library = $this->get_instance( array( 'include_v4_shim' => true ) );
+
+		$library->add_editor_styles();
+		$library->add_editor_styles();
 
 		$this->assertSame(
-			array(),
-			$GLOBALS['bfa_test_editor_styles'],
-			'Font Awesome styles must not be registered as global editor styles.'
+			array(
+				'theme-editor.css',
+				'https://use.fontawesome.com/releases/v5.15.4/css/all.css',
+				'https://use.fontawesome.com/releases/v5.15.4/css/v4-shims.css',
+			),
+			get_editor_stylesheets()
 		);
-		$this->assertArrayHasKey( 'mce_css', $GLOBALS['bfa_test_filter_callbacks'] );
-		$this->assertSame(
-			'wp-content.css,https://use.fontawesome.com/releases/v5.15.4/css/all.css,https://use.fontawesome.com/releases/v5.15.4/css/v4-shims.css',
-			apply_filters( 'mce_css', 'wp-content.css' )
-		);
-		$this->assertSame(
-			'https://use.fontawesome.com/releases/v5.15.4/css/all.css,https://use.fontawesome.com/releases/v5.15.4/css/v4-shims.css',
-			apply_filters( 'mce_css', '' )
-		);
+	}
+
+	public function test_automatic_admin_callback_keeps_established_priority_and_is_removable() {
+		$library = $this->get_instance( array( 'include_v4_shim' => true ) );
+
+		$this->assertSame( 15, has_action( 'admin_enqueue_scripts', array( $library, 'register_font_awesome_css' ) ) );
+		$this->assertTrue( remove_action( 'admin_enqueue_scripts', array( $library, 'register_font_awesome_css' ), 15 ) );
+		do_action( 'admin_enqueue_scripts', 'plugins.php' );
+
+		$this->assertArrayNotHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_enqueued_styles'] );
+		$this->assertArrayNotHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_enqueued_styles'] );
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,6 +22,12 @@ class WP_Error {
 	}
 }
 
+class BFA_Test_Current_Screen {
+	public function is_block_editor() {
+		return $GLOBALS['bfa_test_is_block_editor'];
+	}
+}
+
 function bfa_test_reset_wordpress_state() {
 	$GLOBALS['bfa_test_actions']          = array();
 	$GLOBALS['bfa_test_action_callbacks'] = array();
@@ -35,7 +41,7 @@ function bfa_test_reset_wordpress_state() {
 	$GLOBALS['bfa_test_http_calls']       = 0;
 	$GLOBALS['bfa_test_http_response']    = new WP_Error( 'unexpected_http', 'Unexpected HTTP request.' );
 	$GLOBALS['bfa_test_inline_styles']    = array();
-	$GLOBALS['bfa_test_is_admin']         = false;
+	$GLOBALS['bfa_test_has_current_screen'] = true;
 	$GLOBALS['bfa_test_is_block_editor']  = false;
 	$GLOBALS['bfa_test_localized']        = array();
 	$GLOBALS['bfa_test_registered_styles'] = array();
@@ -99,6 +105,39 @@ function add_action( $tag, $callback, $priority = 10, $accepted_args = 1 ) {
 	return true;
 }
 
+function has_action( $tag, $callback = false ) {
+	if ( empty( $GLOBALS['bfa_test_action_callbacks'][ $tag ] ) ) {
+		return false;
+	}
+
+	if ( false === $callback ) {
+		return true;
+	}
+
+	foreach ( $GLOBALS['bfa_test_action_callbacks'][ $tag ] as $registered ) {
+		if ( $registered['callback'] === $callback ) {
+			return $registered['priority'];
+		}
+	}
+
+	return false;
+}
+
+function remove_action( $tag, $callback, $priority = 10 ) {
+	if ( empty( $GLOBALS['bfa_test_action_callbacks'][ $tag ] ) ) {
+		return false;
+	}
+
+	foreach ( $GLOBALS['bfa_test_action_callbacks'][ $tag ] as $key => $registered ) {
+		if ( $registered['callback'] === $callback && $registered['priority'] === $priority ) {
+			unset( $GLOBALS['bfa_test_action_callbacks'][ $tag ][ $key ] );
+			return true;
+		}
+	}
+
+	return false;
+}
+
 function do_action( $tag ) {
 	$args = func_get_args();
 	array_shift( $args );
@@ -120,6 +159,16 @@ function do_action( $tag ) {
 	);
 
 	foreach ( $callbacks as $registered ) {
+		$still_registered = false;
+		foreach ( $GLOBALS['bfa_test_action_callbacks'][ $tag ] as $current ) {
+			if ( $current['callback'] === $registered['callback'] && $current['priority'] === $registered['priority'] ) {
+				$still_registered = true;
+				break;
+			}
+		}
+		if ( ! $still_registered ) {
+			continue;
+		}
 		call_user_func_array( $registered['callback'], array_slice( $args, 0, $registered['accepted_args'] ) );
 	}
 }
@@ -160,16 +209,12 @@ function add_editor_style( $url ) {
 	$GLOBALS['bfa_test_editor_styles'][] = $url;
 }
 
-function is_admin() {
-	return $GLOBALS['bfa_test_is_admin'];
+function get_editor_stylesheets() {
+	return array_values( array_unique( array_filter( $GLOBALS['bfa_test_editor_styles'] ) ) );
 }
 
 function get_current_screen() {
-	return new class() {
-		public function is_block_editor() {
-			return $GLOBALS['bfa_test_is_block_editor'];
-		}
-	};
+	return $GLOBALS['bfa_test_has_current_screen'] ? new BFA_Test_Current_Screen() : null;
 }
 
 function get_transient( $key ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -35,6 +35,8 @@ function bfa_test_reset_wordpress_state() {
 	$GLOBALS['bfa_test_http_calls']       = 0;
 	$GLOBALS['bfa_test_http_response']    = new WP_Error( 'unexpected_http', 'Unexpected HTTP request.' );
 	$GLOBALS['bfa_test_inline_styles']    = array();
+	$GLOBALS['bfa_test_is_admin']         = false;
+	$GLOBALS['bfa_test_is_block_editor']  = false;
 	$GLOBALS['bfa_test_localized']        = array();
 	$GLOBALS['bfa_test_registered_styles'] = array();
 	$GLOBALS['bfa_test_removed_shortcodes'] = array();
@@ -156,6 +158,18 @@ function trailingslashit( $value ) {
 
 function add_editor_style( $url ) {
 	$GLOBALS['bfa_test_editor_styles'][] = $url;
+}
+
+function is_admin() {
+	return $GLOBALS['bfa_test_is_admin'];
+}
+
+function get_current_screen() {
+	return new class() {
+		public function is_block_editor() {
+			return $GLOBALS['bfa_test_is_block_editor'];
+		}
+	};
 }
 
 function get_transient( $key ) {


### PR DESCRIPTION
## Summary

- suppress only BFAL's automatic priority 15 admin Font Awesome enqueue on Block Editor screens
- preserve deliberate direct calls to public `register_font_awesome_css()` in every context
- restore `add_editor_styles()` to the exact established `add_editor_style()` behavior
- preserve frontend styles, the optional v4 shim, Classic Editor and TinyMCE behavior, existing callback removal, and metadata ownership and transport behavior

No BFAL or Font Awesome version was changed. This remains an implementation review before any potential `2.1.0-rc.2` release preparation.

## Root cause and correction

WordPress 7.1 uses an iframe for the post editor and processes admin styles for iframe compatibility. BFAL's automatic `admin_enqueue_scripts` callback enqueued the cross-origin Font Awesome styles on every admin screen. The Font Awesome CDN responses omit `Access-Control-Allow-Origin`, so the Block Editor iframe processing path failed both versioned CSS requests and logged CORS errors.

The focused correction adds one named internal lifecycle callback at priority 14. On a confirmed Block Editor screen, it removes only BFAL's established `register_font_awesome_css()` callback at priority 15 for that automatic admin hook execution. The public registration method itself is unchanged from the base release, so another consumer can still call it deliberately on the same screen. Normal admin screens, frontend requests, null or unavailable current screens, and third-party `remove_action()` integrations retain their established behavior.

The earlier `mce_css` rewrite was removed. `add_editor_styles()` again calls WordPress `add_editor_style()` exactly as it did in base `a05508043ea885fa611f559ab59cff73161b37d2`, retaining WordPress's existing editor stylesheet preservation and deduplication.

## Rejected alternatives

- Keeping the Block Editor guard inside public `register_font_awesome_css()` would break deliberate direct calls by existing consumers.
- Replacing `add_editor_style()` with an anonymous `mce_css` filter would change the established editor style contract unnecessarily.
- A local versioned Font Awesome CSS copy would break the live, version-coupled CDN architecture.
- A proxy, CORS workaround, generalized registration API, or ownership API would add unrelated architecture for a screen-specific automatic enqueue issue.
- Loading Font Awesome into the Block Editor canvas is unnecessary because BFA's Shortcode block has no live icon preview.

## Public-contract regression coverage

- automatic admin enqueue omits both Font Awesome handles on Block Editor screens
- a direct public registration call on that same screen enqueues `all.css` and the enabled v4 shim
- normal admin and frontend automatic loading remain unchanged
- null current screens fail open without errors
- enabled and disabled v4 shim behavior remains unchanged
- existing editor styles are preserved and repeated `add_editor_styles()` calls deduplicate through WordPress's established mechanism
- the automatic public callback remains registered at priority 15 and can still be removed with `remove_action()`

## Validation

- BFAL PHPUnit: 94 tests, 407 assertions on PHP 7.4, 8.0, 8.1, 8.2, 8.3, and 8.4
- Composer validation and audit: passed with no advisories
- PHPCS: passed
- PHPStan: passed with a 1 GiB limit
- tracked browser asset rebuild: no generated changes
- shipped runtime asset audit and `npm audit --omit=dev`: no vulnerabilities
- root npm audit: 3 existing high-severity development-only lodash findings, unchanged and excluded from production
- production archive: two byte-identical builds from commit `19c0e85e9b47ad574fb7be6fa18a0f209a61edc3`, 18 production files, one exact root directory, no runtime Composer dependencies, and no development or agent files
- production archive SHA-256: `5023351673254bfddf3e51b02040f19d9a870828b269972bf63d23973772b259`

### Browser and BFA integration evidence

- WordPress 7.1, PHP 8.3, Font Awesome 5.15.4, v4 shim enabled: the iframed Block Editor made no `all.css` or `v4-shims.css` request, logged no Font Awesome CORS or BFA/BFAL console error, and preserved an edited Shortcode block
- WordPress 6.5 with Classic Editor 1.7.0: TinyMCE received the live versioned `all.css` and enabled `v4-shims.css`; the picker rendered, search worked, insertion produced the expected shortcode, computed Font Awesome glyph styling was present, and the frontend rendered the shortcode
- non-editor Plugins screen: versioned `all.css` and `v4-shims.css` remained loaded
- frontend: versioned CDN `all.css` and optional `v4-shims.css` remained loaded and v4 rendering remained unchanged
- WP-CLI and null-screen initialization remained safe and failed open to established loading behavior
- BFA PR #52 exact head `1f0edcb7bf2b4ec800ebbe55f009cf7dcb570990`: single-site 77 tests with 17,687 assertions and multisite 77 tests with 17,706 assertions passed against the corrected BFAL checkout in the ignored generated vendor tree
- BFA packaged-plugin smoke: the release-tree audit passed, the packaged BFAL runtime file exactly matched this commit, WordPress 7.1 loaded it from the generated package, the iframe edit persisted with zero Font Awesome requests, and frontend rendering retained both styles

The disposable BFA checkout remained clean. No BFA dependency manifest, lockfile, or source file was changed.
