### PR TITLE
Keep mixed-editor pickers styled outside block canvas

### DIFF
--- a/better-font-awesome-library.php
+++ b/better-font-awesome-library.php
@@ -969,14 +969,23 @@ class Better_Font_Awesome_Library {
 	 * @internal
 	 */
 	public function disable_block_editor_font_awesome_css() {
+		if ( $this->is_block_editor_screen() ) {
+			remove_action( 'admin_enqueue_scripts', array( $this, 'register_font_awesome_css' ), 15 );
+		}
+	}
+
+	/**
+	 * Determine whether the current admin screen uses the Block Editor.
+	 *
+	 * @return bool Whether this is a Block Editor screen.
+	 */
+	private function is_block_editor_screen() {
 		if ( ! function_exists( 'get_current_screen' ) ) {
-			return;
+			return false;
 		}
 
 		$screen = get_current_screen();
-		if ( $screen && is_callable( array( $screen, 'is_block_editor' ) ) && $screen->is_block_editor() ) {
-			remove_action( 'admin_enqueue_scripts', array( $this, 'register_font_awesome_css' ), 15 );
-		}
+		return $screen && is_callable( array( $screen, 'is_block_editor' ) ) && $screen->is_block_editor();
 	}
 
 	/**
@@ -1123,12 +1132,147 @@ class Better_Font_Awesome_Library {
 		);
 
 		// Output PHP variables to JS.
+		$picker_stylesheets = array(
+			array(
+				'id'  => self::SLUG . '-font-awesome-css',
+				'url' => $this->get_stylesheet_url(),
+			),
+		);
+		if ( $this->args['include_v4_shim'] ) {
+			$picker_stylesheets[] = array(
+				'id'  => self::SLUG . '-font-awesome-v4-shim-css',
+				'url' => $this->get_stylesheet_url_v4_shim(),
+			);
+		}
+
 		$bfa_vars = array(
-			'fa_prefix'   => $this->get_prefix(),
-			'fa_icons'    => $this->get_icons(),
+			'fa_prefix'             => $this->get_prefix(),
+			'fa_icons'              => $this->get_icons(),
+			'fa_picker_stylesheets' => $picker_stylesheets,
+			'is_block_editor'       => $this->is_block_editor_screen(),
 		);
 		wp_localize_script( self::SLUG . '-admin', 'bfa_vars', $bfa_vars );
+		wp_add_inline_script( self::SLUG . '-admin', $this->get_picker_stylesheet_loader_script(), 'before' );
 
+	}
+
+	/**
+	 * Return the parent-document stylesheet loader used before picker setup.
+	 *
+	 * Loading after the editor canvas is ready keeps the styles out of the Block
+	 * Editor iframe compatibility scan. The interaction guard also covers picker
+	 * markup introduced after the initial document render.
+	 *
+	 * @return string Picker stylesheet loader.
+	 */
+	private function get_picker_stylesheet_loader_script() {
+		return <<<'JS'
+( function() {
+	var pickerPreparationAttempts = 0;
+
+	function findStylesheet( stylesheet ) {
+		return document.getElementById( stylesheet.id );
+	}
+
+	function stylesheetReady( stylesheet ) {
+		var link = findStylesheet( stylesheet );
+		return !! ( link && link.sheet );
+	}
+
+	function loadStylesheet( stylesheet ) {
+		return new Promise( function( resolve, reject ) {
+			var link = findStylesheet( stylesheet );
+			if ( link && link.sheet ) {
+				resolve();
+				return;
+			}
+			if ( ! link ) {
+				link = document.createElement( 'link' );
+				link.id = stylesheet.id;
+				link.rel = 'stylesheet';
+				link.href = stylesheet.url;
+				link.addEventListener( 'load', resolve, { once: true } );
+				link.addEventListener( 'error', reject, { once: true } );
+				document.head.appendChild( link );
+				return;
+			}
+			link.addEventListener( 'load', resolve, { once: true } );
+			link.addEventListener( 'error', reject, { once: true } );
+		} );
+	}
+
+	function loadPickerStylesheets() {
+		var stylesheets = window.bfa_vars.fa_picker_stylesheets || [];
+		return Promise.all( stylesheets.map( loadStylesheet ) );
+	}
+
+	function editorCanvasReady() {
+		var canvas;
+		if ( ! window.bfa_vars.is_block_editor ) {
+			return true;
+		}
+		canvas = document.querySelector( 'iframe[name="editor-canvas"]' );
+		if ( canvas ) {
+			return !! ( canvas.contentDocument && canvas.contentDocument.documentElement.classList.contains( 'block-editor-iframe__html' ) );
+		}
+		return !! document.querySelector( '.block-editor-writing-flow' );
+	}
+
+	function prepareRenderedPickers() {
+		pickerPreparationAttempts++;
+		if ( ! document.querySelector( '.bfa-iconpicker' ) || ! editorCanvasReady() ) {
+			if ( pickerPreparationAttempts < 200 ) {
+				window.setTimeout( prepareRenderedPickers, 50 );
+			}
+			return;
+		}
+		loadPickerStylesheets().catch( function() {} );
+	}
+
+	document.addEventListener( 'mousedown', function( event ) {
+		var picker;
+		var stylesheets;
+		if ( event.bfalPickerStylesReady || ! event.target.closest ) {
+			return;
+		}
+		picker = event.target.closest( '.bfa-iconpicker' );
+		if ( ! picker || ! window.bfa_vars ) {
+			return;
+		}
+		stylesheets = window.bfa_vars.fa_picker_stylesheets || [];
+		if ( stylesheets.every( stylesheetReady ) ) {
+			return;
+		}
+		event.preventDefault();
+		event.stopImmediatePropagation();
+		if ( picker.getAttribute( 'data-bfa-styles-loading' ) ) {
+			return;
+		}
+		picker.setAttribute( 'data-bfa-styles-loading', 'true' );
+		loadPickerStylesheets().then( function() {
+			var component;
+			var replay = new MouseEvent( 'mousedown', { bubbles: true, cancelable: true, view: window } );
+			replay.bfalPickerStylesReady = true;
+			picker.removeAttribute( 'data-bfa-styles-loading' );
+			picker.dispatchEvent( replay );
+			if ( ! picker.classList.contains( 'initialized' ) ) {
+				component = picker.querySelector( '.iconpicker-component' );
+				if ( component ) {
+					component.click();
+				}
+			}
+		}, function() {
+			picker.removeAttribute( 'data-bfa-styles-loading' );
+		} );
+	}, true );
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', prepareRenderedPickers );
+	} else {
+		prepareRenderedPickers();
+	}
+} )();
+JS;
 	}
 
 	/**

--- a/tests/EditorStylesTest.php
+++ b/tests/EditorStylesTest.php
@@ -61,6 +61,50 @@ class EditorStylesTest extends BfalTestCase {
 		$this->assertArrayNotHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_enqueued_styles'] );
 	}
 
+	public function test_picker_receives_parent_document_stylesheet_dependencies_with_v4_shim() {
+		$this->get_instance( array( 'include_v4_shim' => true ) );
+		$GLOBALS['bfa_test_is_block_editor'] = true;
+
+		do_action( 'admin_enqueue_scripts', 'post.php' );
+
+		$this->assertSame(
+			array(
+				array(
+					'id'  => 'bfa-font-awesome-css',
+					'url' => 'https://use.fontawesome.com/releases/v5.15.4/css/all.css',
+				),
+				array(
+					'id'  => 'bfa-font-awesome-v4-shim-css',
+					'url' => 'https://use.fontawesome.com/releases/v5.15.4/css/v4-shims.css',
+				),
+			),
+			$GLOBALS['bfa_test_localized']['bfa-admin']['data']['fa_picker_stylesheets']
+		);
+		$this->assertSame( 'before', $GLOBALS['bfa_test_inline_scripts']['bfa-admin']['position'] );
+		$this->assertTrue( $GLOBALS['bfa_test_localized']['bfa-admin']['data']['is_block_editor'] );
+		$this->assertStringContainsString(
+			'data-bfa-styles-loading',
+			$GLOBALS['bfa_test_inline_scripts']['bfa-admin']['data']
+		);
+	}
+
+	public function test_picker_receives_only_main_parent_document_stylesheet_when_v4_shim_is_disabled() {
+		$this->get_instance( array( 'include_v4_shim' => false ) );
+		$GLOBALS['bfa_test_is_block_editor'] = true;
+
+		do_action( 'admin_enqueue_scripts', 'post.php' );
+
+		$this->assertSame(
+			array(
+				array(
+					'id'  => 'bfa-font-awesome-css',
+					'url' => 'https://use.fontawesome.com/releases/v5.15.4/css/all.css',
+				),
+			),
+			$GLOBALS['bfa_test_localized']['bfa-admin']['data']['fa_picker_stylesheets']
+		);
+	}
+
 	public function test_editor_styles_preserve_existing_entries_and_wordpress_deduplication() {
 		$GLOBALS['bfa_test_editor_styles'][] = 'theme-editor.css';
 		$library = $this->get_instance( array( 'include_v4_shim' => true ) );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -41,6 +41,7 @@ function bfa_test_reset_wordpress_state() {
 	$GLOBALS['bfa_test_http_calls']       = 0;
 	$GLOBALS['bfa_test_http_response']    = new WP_Error( 'unexpected_http', 'Unexpected HTTP request.' );
 	$GLOBALS['bfa_test_inline_styles']    = array();
+	$GLOBALS['bfa_test_inline_scripts']   = array();
 	$GLOBALS['bfa_test_has_current_screen'] = true;
 	$GLOBALS['bfa_test_is_block_editor']  = false;
 	$GLOBALS['bfa_test_localized']        = array();
@@ -312,6 +313,10 @@ function wp_enqueue_script( $handle, $src = '', $dependencies = array(), $versio
 
 function wp_add_inline_style( $handle, $css ) {
 	$GLOBALS['bfa_test_inline_styles'][ $handle ] = $css;
+}
+
+function wp_add_inline_script( $handle, $data, $position = 'after' ) {
+	$GLOBALS['bfa_test_inline_scripts'][ $handle ] = compact( 'data', 'position' );
 }
 
 function wp_localize_script( $handle, $name, $data ) {

--- a/tests/browser/fixtures/wp-editor-meta-box.php
+++ b/tests/browser/fixtures/wp-editor-meta-box.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Mixed Block Editor and wp_editor() fixture for browser regression testing.
+ *
+ * Define BFAL_BROWSER_FIXTURE_EDITOR_COUNT before loading this file to render
+ * multiple traditional editors. Define BFAL_BROWSER_FIXTURE_DYNAMIC as true to
+ * include a client-initialized editor and picker trigger.
+ *
+ * @package Better_Font_Awesome_Library
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$bfal_fixture_editor_count = defined( 'BFAL_BROWSER_FIXTURE_EDITOR_COUNT' )
+	? max( 1, (int) BFAL_BROWSER_FIXTURE_EDITOR_COUNT )
+	: 1;
+
+add_action(
+	'add_meta_boxes_post',
+	static function () use ( $bfal_fixture_editor_count ) {
+		for ( $index = 1; $index <= $bfal_fixture_editor_count; ++$index ) {
+			$editor_id = 'bfal_fixture_editor_' . $index;
+			add_meta_box(
+				'bfal-wp-editor-fixture-' . $index,
+				'BFAL traditional editor fixture ' . $index,
+				static function () use ( $editor_id, $index ) {
+					wp_editor(
+						'Traditional editor fixture content ' . $index . '.',
+						$editor_id,
+						array(
+							'media_buttons' => true,
+							'textarea_rows' => 4,
+						)
+					);
+				},
+				'post',
+				'normal',
+				'default'
+			);
+		}
+
+		if ( defined( 'BFAL_BROWSER_FIXTURE_DYNAMIC' ) && BFAL_BROWSER_FIXTURE_DYNAMIC ) {
+			add_meta_box(
+				'bfal-dynamic-wp-editor-fixture',
+				'BFAL dynamic editor fixture',
+				static function () {
+					?>
+					<button type="button" class="button" id="bfal-add-dynamic-editor">Initialize dynamic editor</button>
+					<div id="bfal-dynamic-editor-host" hidden>
+						<div id="wp-bfal_dynamic_editor-media-buttons" class="wp-media-buttons">
+							<?php do_action( 'media_buttons', 'bfal_dynamic_editor' ); ?>
+						</div>
+						<textarea id="bfal_dynamic_editor">Dynamic editor fixture content.</textarea>
+					</div>
+					<script>
+						document.getElementById( 'bfal-add-dynamic-editor' ).addEventListener( 'click', function() {
+							var host = document.getElementById( 'bfal-dynamic-editor-host' );
+							host.hidden = false;
+							wp.editor.initialize( 'bfal_dynamic_editor', {
+								tinymce: true,
+								quicktags: true
+							} );
+							this.disabled = true;
+						} );
+					</script>
+					<?php
+				},
+				'post',
+				'normal',
+				'default'
+			);
+		}
+	}
+);
+
+if ( defined( 'BFAL_BROWSER_FIXTURE_DYNAMIC' ) && BFAL_BROWSER_FIXTURE_DYNAMIC ) {
+	add_action( 'admin_enqueue_scripts', 'wp_enqueue_editor' );
+}


### PR DESCRIPTION
## Summary

- keep BFAL's automatic Font Awesome styles out of the WordPress 7.1 Block Editor canvas
- load the live version-coupled glyph styles in the parent document only when BFAL renders a picker there
- preserve TinyMCE editor styles, frontend styles, direct registration calls, and the optional v4 shim
- add focused lifecycle coverage and a reusable mixed Block Editor plus `wp_editor()` browser fixture

## Root cause

PR #41 correctly suppressed BFAL's automatic parent-page Font Awesome enqueue on Block Editor screens, preventing WordPress 7.1 from processing the cross-origin styles in its editor iframe. A Block Editor screen can also contain traditional `wp_editor()` meta boxes, however. BFAL still rendered and initialized its `media_buttons` picker in the parent document while the glyph dependency existed only in TinyMCE, leaving picker icons blank.

## Correction

BFAL now localizes the existing live release stylesheet URLs for picker use. A small pre-initialization loader waits until the Block Editor canvas compatibility pass is complete, then loads those styles only in the parent document when picker markup exists. A capture guard covers late picker interactions and dynamically initialized editors. The existing generated browser assets are unchanged.

The public constructor, singleton, direct `register_font_awesome_css()` calls, editor style API, metadata provider, transport, validation, cache, fallback, shortcode, and frontend behavior are unchanged.

## Verification

- regression reproduced on merge commit `02d9706d743a0ae6e7955f8aa6b2c9e43bdc329e`: Block Editor iframe had no Font Awesome requests, TinyMCE had both styles, but the parent picker glyph had no Font Awesome font or pseudo-element content
- WordPress 7.1, PHP 8.3, Block Editor without `wp_editor()`: no Font Awesome requests, no iframe or parent styles, no CORS errors, Shortcode block saved intact
- WordPress 7.1 with two traditional editors and one dynamically initialized editor: all picker glyphs, search, and insertion passed; TinyMCE retained its styles; Block Editor iframe contained no Font Awesome links; v4 shim enabled and disabled both passed
- WordPress 6.5 Classic Editor: TinyMCE and picker glyphs passed, search returned expected results, insertion produced the expected shortcode, and frontend rendering retained versioned `all.css` plus optional `v4-shims.css`
- WordPress 6.5 Block Editor plus multiple and dynamic traditional editors passed picker behavior
- BFA PR #52 exact head `1f0edcb7bf2b4ec800ebbe55f009cf7dcb570990`: single-site 77 tests and 17,687 assertions; multisite 77 tests and 17,706 assertions
- BFAL PHPUnit: 96 tests and 412 assertions on PHP 7.4, 8.0, 8.1, 8.2, 8.3, and 8.4
- Composer strict validation and audit, PHPCS, PHPStan, runtime asset audit, browser asset rebuild, and packaged-plugin smoke passed
- production archive built twice byte-identically with the same 18-file layout as `2.1.0-rc.1`; tests, agent files, development files, `node_modules`, and `vendor` remain excluded

This PR does not change the BFAL version and does not prepare or publish `2.1.0-rc.2`.
