### PR TITLE
Normalize Font Awesome CDN stylesheet request mode

### DIFF
--- a/better-font-awesome-library.php
+++ b/better-font-awesome-library.php
@@ -983,24 +983,29 @@ class Better_Font_Awesome_Library {
 	 */
 	private function add_font_awesome_crossorigin_attribute( $html, $handle ) {
 		$font_awesome_handles = array(
-			self::SLUG . '-font-awesome',
-			self::SLUG . '-font-awesome-v4-shim',
+			self::SLUG . '-font-awesome'         => self::SLUG . '-font-awesome-css',
+			self::SLUG . '-font-awesome-v4-shim' => self::SLUG . '-font-awesome-v4-shim-css',
 		);
 
-		if ( ! in_array( $handle, $font_awesome_handles, true ) || ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
+		if ( ! isset( $font_awesome_handles[ $handle ] ) || ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
 			return $html;
 		}
 
-		$processor = new WP_HTML_Tag_Processor( $html );
-		if ( ! $processor->next_tag( array( 'tag_name' => 'LINK' ) ) ) {
-			return $html;
+		$processor   = new WP_HTML_Tag_Processor( $html );
+		$expected_id = $font_awesome_handles[ $handle ];
+		while ( $processor->next_tag( array( 'tag_name' => 'LINK' ) ) ) {
+			if ( $expected_id !== $processor->get_attribute( 'id' ) ) {
+				continue;
+			}
+
+			if ( ! $processor->set_attribute( 'crossorigin', 'anonymous' ) ) {
+				return $html;
+			}
+
+			return $processor->get_updated_html();
 		}
 
-		if ( ! $processor->set_attribute( 'crossorigin', 'anonymous' ) ) {
-			return $html;
-		}
-
-		return $processor->get_updated_html();
+		return $html;
 	}
 
 	/**

--- a/better-font-awesome-library.php
+++ b/better-font-awesome-library.php
@@ -249,6 +249,20 @@ class Better_Font_Awesome_Library {
 		// Initialize library properties and actions as needed.
 		$this->initialize( $this->args );
 
+		/*
+		 * Keep BFAL's CDN styles in anonymous CORS mode on every normal load.
+		 * This prevents a non-CORS response for the immutable URL from being
+		 * cached before WordPress requests the same URL in an isolated editor.
+		 */
+		add_filter(
+			'style_loader_tag',
+			function ( $html, $handle ) {
+				return $this->add_font_awesome_crossorigin_attribute( $html, $handle );
+			},
+			10,
+			2
+		);
+
 		// Add Font Awesome and/or custom CSS to the editor.
 		$this->add_editor_styles();
 
@@ -285,7 +299,6 @@ class Better_Font_Awesome_Library {
 		 * Use priority 15 to make sure styles/scripts load after other plugins.
 		 */
 		if ( $this->args['load_admin_styles'] || $this->args['load_tinymce_plugin'] ) {
-			add_action( 'admin_enqueue_scripts', array( $this, 'disable_block_editor_font_awesome_css' ), 14 );
 			add_action( 'admin_enqueue_scripts', array( $this, 'register_font_awesome_css' ), 15 );
 		}
 
@@ -960,23 +973,34 @@ class Better_Font_Awesome_Library {
 	}
 
 	/**
-	 * Disable BFAL's automatic Font Awesome enqueue on Block Editor screens.
-	 *
-	 * This is an internal lifecycle callback for the admin enqueue hook, not an
-	 * integration API. Direct calls to register_font_awesome_css() are unchanged.
+	 * Add anonymous CORS mode to BFAL's enqueued Font Awesome stylesheets.
 	 *
 	 * @since  2.1.0
-	 * @internal
+	 *
+	 * @param  string  $html    The stylesheet link tag.
+	 * @param  string  $handle  The stylesheet handle.
+	 * @return string  The filtered stylesheet link tag.
 	 */
-	public function disable_block_editor_font_awesome_css() {
-		if ( ! function_exists( 'get_current_screen' ) ) {
-			return;
+	private function add_font_awesome_crossorigin_attribute( $html, $handle ) {
+		$font_awesome_handles = array(
+			self::SLUG . '-font-awesome',
+			self::SLUG . '-font-awesome-v4-shim',
+		);
+
+		if ( ! in_array( $handle, $font_awesome_handles, true ) || ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
+			return $html;
 		}
 
-		$screen = get_current_screen();
-		if ( $screen && is_callable( array( $screen, 'is_block_editor' ) ) && $screen->is_block_editor() ) {
-			remove_action( 'admin_enqueue_scripts', array( $this, 'register_font_awesome_css' ), 15 );
+		$processor = new WP_HTML_Tag_Processor( $html );
+		if ( ! $processor->next_tag( array( 'tag_name' => 'LINK' ) ) ) {
+			return $html;
 		}
+
+		if ( ! $processor->set_attribute( 'crossorigin', 'anonymous' ) ) {
+			return $html;
+		}
+
+		return $processor->get_updated_html();
 	}
 
 	/**

--- a/tests/EditorStylesTest.php
+++ b/tests/EditorStylesTest.php
@@ -3,14 +3,76 @@
 require_once __DIR__ . '/BfalTestCase.php';
 
 class EditorStylesTest extends BfalTestCase {
-	public function test_automatic_admin_enqueue_skips_block_editor_screens() {
+	public function test_automatic_admin_enqueue_remains_active_on_block_editor_screens() {
 		$this->get_instance( array( 'include_v4_shim' => true ) );
 		$GLOBALS['bfa_test_is_block_editor'] = true;
 
 		do_action( 'admin_enqueue_scripts', 'post.php' );
 
-		$this->assertArrayNotHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_enqueued_styles'] );
-		$this->assertArrayNotHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_enqueued_styles'] );
+		$this->assertArrayHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_enqueued_styles'] );
+		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_enqueued_styles'] );
+	}
+
+	public function test_font_awesome_stylesheet_tags_use_anonymous_cors() {
+		$this->get_instance();
+		$main = '<link rel="stylesheet" id="bfa-font-awesome-css" href="https://use.fontawesome.com/all.css" media="all" />';
+		$shim = '<link rel="stylesheet" id="bfa-font-awesome-v4-shim-css" href="https://use.fontawesome.com/v4-shims.css" media="all" />';
+
+		$this->assertSame( 1, substr_count( apply_filters( 'style_loader_tag', $main, 'bfa-font-awesome' ), 'crossorigin="anonymous"' ) );
+		$this->assertSame( 1, substr_count( apply_filters( 'style_loader_tag', $shim, 'bfa-font-awesome-v4-shim' ), 'crossorigin="anonymous"' ) );
+	}
+
+	public function test_unrelated_stylesheet_tag_is_byte_for_byte_unchanged() {
+		$this->get_instance();
+		$tag = "<link data-example='one' rel=\"stylesheet\" href=\"theme.css\" />\n";
+
+		$this->assertSame( $tag, apply_filters( 'style_loader_tag', $tag, 'theme-style' ) );
+	}
+
+	public function test_existing_anonymous_cors_attribute_is_idempotent() {
+		$this->get_instance();
+		$tag  = '<link rel="stylesheet" crossorigin="anonymous" href="all.css" />';
+		$once = apply_filters( 'style_loader_tag', $tag, 'bfa-font-awesome' );
+
+		$this->assertSame( 1, substr_count( $once, 'crossorigin="anonymous"' ) );
+		$this->assertSame( $once, apply_filters( 'style_loader_tag', $once, 'bfa-font-awesome' ) );
+	}
+
+	public function test_other_cors_value_is_normalized_without_changing_other_attributes() {
+		$this->get_instance();
+		$tag = '<link data-before="kept" crossorigin="use-credentials" rel="stylesheet" href="all.css" data-after="also-kept">';
+
+		$this->assertSame(
+			'<link data-before="kept" crossorigin="anonymous" rel="stylesheet" href="all.css" data-after="also-kept">',
+			apply_filters( 'style_loader_tag', $tag, 'bfa-font-awesome' )
+		);
+	}
+
+	/**
+	 * @dataProvider unexpected_stylesheet_markup_provider
+	 */
+	public function test_unexpected_markup_fails_safely( $markup ) {
+		$this->get_instance();
+
+		$this->assertSame( $markup, apply_filters( 'style_loader_tag', $markup, 'bfa-font-awesome' ) );
+	}
+
+	public function unexpected_stylesheet_markup_provider() {
+		return array(
+			'empty'          => array( '' ),
+			'plain text'     => array( 'not a link tag' ),
+			'incomplete tag' => array( '<link rel="stylesheet"' ),
+			'other tag'      => array( '<style>.fa { display: block; }</style>' ),
+		);
+	}
+
+	public function test_cors_filter_is_registered_once_at_priority_ten_for_two_arguments() {
+		$this->get_instance();
+
+		$this->assertTrue( has_filter( 'style_loader_tag' ) );
+		$this->assertCount( 1, $GLOBALS['bfa_test_filter_callbacks']['style_loader_tag'] );
+		$this->assertSame( 10, $GLOBALS['bfa_test_filter_callbacks']['style_loader_tag'][0]['priority'] );
+		$this->assertSame( 2, $GLOBALS['bfa_test_filter_callbacks']['style_loader_tag'][0]['accepted_args'] );
 	}
 
 	public function test_direct_registration_remains_available_on_block_editor_screens() {

--- a/tests/EditorStylesTest.php
+++ b/tests/EditorStylesTest.php
@@ -29,9 +29,66 @@ class EditorStylesTest extends BfalTestCase {
 		$this->assertSame( $tag, apply_filters( 'style_loader_tag', $tag, 'theme-style' ) );
 	}
 
+	public function test_preceding_preload_link_is_unchanged_and_main_stylesheet_is_targeted() {
+		$this->get_instance();
+		$preload = '<link rel="preload" href="https://optimizer.test/font.css" as="font">' . "\n";
+		$main    = '<link rel="stylesheet" id="bfa-font-awesome-css" href="https://use.fontawesome.com/all.css">';
+
+		$this->assertSame(
+			$preload . '<link rel="stylesheet" id="bfa-font-awesome-css" href="https://use.fontawesome.com/all.css" crossorigin="anonymous">',
+			apply_filters( 'style_loader_tag', $preload . $main, 'bfa-font-awesome' )
+		);
+	}
+
+	public function test_preceding_stylesheet_link_is_unchanged_and_main_stylesheet_is_targeted() {
+		$this->get_instance();
+		$theme = '<link data-optimizer="kept" rel="stylesheet" id="theme-css" href="theme.css">' . "\n";
+		$main  = '<link rel="stylesheet" id="bfa-font-awesome-css" href="https://use.fontawesome.com/all.css">';
+
+		$this->assertSame(
+			$theme . '<link rel="stylesheet" id="bfa-font-awesome-css" href="https://use.fontawesome.com/all.css" crossorigin="anonymous">',
+			apply_filters( 'style_loader_tag', $theme . $main, 'bfa-font-awesome' )
+		);
+	}
+
+	public function test_following_link_is_unchanged_when_main_stylesheet_is_targeted() {
+		$this->get_instance();
+		$main      = '<link rel="stylesheet" id="bfa-font-awesome-css" href="https://use.fontawesome.com/all.css">';
+		$following = "\n" . '<link rel="stylesheet" id="theme-css" href="theme.css" data-after="kept">';
+
+		$this->assertSame(
+			'<link rel="stylesheet" id="bfa-font-awesome-css" href="https://use.fontawesome.com/all.css" crossorigin="anonymous">' . $following,
+			apply_filters( 'style_loader_tag', $main . $following, 'bfa-font-awesome' )
+		);
+	}
+
+	public function test_only_exact_expected_id_is_changed_among_multiple_links() {
+		$this->get_instance();
+		$input = '<link rel="preload" id="optimizer-preload" href="preload.css">' . "\n"
+			. '<link rel="stylesheet" id="bfa-font-awesome-css-copy" crossorigin="use-credentials" href="copy.css">' . "\n"
+			. '<link rel="stylesheet" id="bfa-font-awesome-css" crossorigin="use-credentials" href="all.css">' . "\n"
+			. '<link rel="stylesheet" id="theme-css" href="theme.css">';
+		$expected = '<link rel="preload" id="optimizer-preload" href="preload.css">' . "\n"
+			. '<link rel="stylesheet" id="bfa-font-awesome-css-copy" crossorigin="use-credentials" href="copy.css">' . "\n"
+			. '<link rel="stylesheet" id="bfa-font-awesome-css" crossorigin="anonymous" href="all.css">' . "\n"
+			. '<link rel="stylesheet" id="theme-css" href="theme.css">';
+
+		$this->assertSame( $expected, apply_filters( 'style_loader_tag', $input, 'bfa-font-awesome' ) );
+	}
+
+	public function test_allowed_handle_without_expected_id_returns_complete_markup_unchanged() {
+		$this->get_instance();
+		$input = '<link rel="preload" id="optimizer-preload" href="preload.css">' . "\n"
+			. '<link rel="stylesheet" id="different-css" href="all.css">' . "\n"
+			. '<link rel="stylesheet" id="theme-css" href="theme.css">';
+
+		$this->assertSame( $input, apply_filters( 'style_loader_tag', $input, 'bfa-font-awesome' ) );
+		$this->assertSame( $input, apply_filters( 'style_loader_tag', $input, 'bfa-font-awesome-v4-shim' ) );
+	}
+
 	public function test_existing_anonymous_cors_attribute_is_idempotent() {
 		$this->get_instance();
-		$tag  = '<link rel="stylesheet" crossorigin="anonymous" href="all.css" />';
+		$tag  = '<link rel="stylesheet" id="bfa-font-awesome-css" crossorigin="anonymous" href="all.css" />';
 		$once = apply_filters( 'style_loader_tag', $tag, 'bfa-font-awesome' );
 
 		$this->assertSame( 1, substr_count( $once, 'crossorigin="anonymous"' ) );
@@ -40,12 +97,24 @@ class EditorStylesTest extends BfalTestCase {
 
 	public function test_other_cors_value_is_normalized_without_changing_other_attributes() {
 		$this->get_instance();
-		$tag = '<link data-before="kept" crossorigin="use-credentials" rel="stylesheet" href="all.css" data-after="also-kept">';
+		$tag = '<link data-before="kept" id="bfa-font-awesome-css" crossorigin="use-credentials" rel="stylesheet" href="all.css" data-after="also-kept">';
 
 		$this->assertSame(
-			'<link data-before="kept" crossorigin="anonymous" rel="stylesheet" href="all.css" data-after="also-kept">',
+			'<link data-before="kept" id="bfa-font-awesome-css" crossorigin="anonymous" rel="stylesheet" href="all.css" data-after="also-kept">',
 			apply_filters( 'style_loader_tag', $tag, 'bfa-font-awesome' )
 		);
+	}
+
+	public function test_v4_shim_exact_target_normalizes_and_remains_idempotent() {
+		$this->get_instance();
+		$tag  = '<link id="bfa-font-awesome-v4-shim-css" rel="stylesheet" crossorigin="use-credentials" href="v4-shims.css">';
+		$once = apply_filters( 'style_loader_tag', $tag, 'bfa-font-awesome-v4-shim' );
+
+		$this->assertSame(
+			'<link id="bfa-font-awesome-v4-shim-css" rel="stylesheet" crossorigin="anonymous" href="v4-shims.css">',
+			$once
+		);
+		$this->assertSame( $once, apply_filters( 'style_loader_tag', $once, 'bfa-font-awesome-v4-shim' ) );
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,6 +24,7 @@ class WP_Error {
 
 class WP_HTML_Tag_Processor {
 	private $html;
+	private $cursor = 0;
 	private $link_offset;
 	private $link_length;
 	private $link_tag;
@@ -37,13 +38,33 @@ class WP_HTML_Tag_Processor {
 			return false;
 		}
 
-		if ( ! preg_match( '/<link(?:\s[^<>]*)?\s*\/?>/i', $this->html, $matches, PREG_OFFSET_CAPTURE ) ) {
+		if ( ! preg_match( '/<link(?:\s[^<>]*)?\s*\/?>/i', $this->html, $matches, PREG_OFFSET_CAPTURE, $this->cursor ) ) {
 			return false;
 		}
 
 		$this->link_tag    = $matches[0][0];
 		$this->link_offset = $matches[0][1];
 		$this->link_length = strlen( $matches[0][0] );
+		$this->cursor      = $this->link_offset + $this->link_length;
+		return true;
+	}
+
+	public function get_attribute( $name ) {
+		if ( null === $this->link_tag ) {
+			return null;
+		}
+
+		$pattern = '/(?<=\s)' . preg_quote( $name, '/' ) . '(?:\s*=\s*(?:"([^"]*)"|\'([^\']*)\'|([^\s>]+)))?/i';
+		if ( ! preg_match( $pattern, $this->link_tag, $matches, PREG_UNMATCHED_AS_NULL ) ) {
+			return null;
+		}
+
+		foreach ( array_slice( $matches, 1 ) as $value ) {
+			if ( null !== $value ) {
+				return html_entity_decode( $value, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+			}
+		}
+
 		return true;
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,6 +22,52 @@ class WP_Error {
 	}
 }
 
+class WP_HTML_Tag_Processor {
+	private $html;
+	private $link_offset;
+	private $link_length;
+	private $link_tag;
+
+	public function __construct( $html ) {
+		$this->html = $html;
+	}
+
+	public function next_tag( $query = null ) {
+		if ( is_array( $query ) && isset( $query['tag_name'] ) && 'LINK' !== strtoupper( $query['tag_name'] ) ) {
+			return false;
+		}
+
+		if ( ! preg_match( '/<link(?:\s[^<>]*)?\s*\/?>/i', $this->html, $matches, PREG_OFFSET_CAPTURE ) ) {
+			return false;
+		}
+
+		$this->link_tag    = $matches[0][0];
+		$this->link_offset = $matches[0][1];
+		$this->link_length = strlen( $matches[0][0] );
+		return true;
+	}
+
+	public function set_attribute( $name, $value ) {
+		if ( null === $this->link_tag ) {
+			return false;
+		}
+
+		$attribute = $name . '="' . $value . '"';
+		$pattern   = '/(?<=\s)' . preg_quote( $name, '/' ) . '(?:\s*=\s*(?:"[^"]*"|\'[^\']*\'|[^\s>]+))?/i';
+		if ( preg_match( $pattern, $this->link_tag ) ) {
+			$this->link_tag = preg_replace( $pattern, $attribute, $this->link_tag, 1 );
+		} else {
+			$this->link_tag = preg_replace( '/(\s*\/?>)$/', ' ' . $attribute . '$1', $this->link_tag, 1 );
+		}
+
+		return true;
+	}
+
+	public function get_updated_html() {
+		return substr_replace( $this->html, $this->link_tag, $this->link_offset, $this->link_length );
+	}
+}
+
 class BFA_Test_Current_Screen {
 	public function is_block_editor() {
 		return $GLOBALS['bfa_test_is_block_editor'];
@@ -103,6 +149,24 @@ function add_action( $tag, $callback, $priority = 10, $accepted_args = 1 ) {
 		'accepted_args' => $accepted_args,
 	);
 	return true;
+}
+
+function has_filter( $tag, $callback = false ) {
+	if ( empty( $GLOBALS['bfa_test_filter_callbacks'][ $tag ] ) ) {
+		return false;
+	}
+
+	if ( false === $callback ) {
+		return true;
+	}
+
+	foreach ( $GLOBALS['bfa_test_filter_callbacks'][ $tag ] as $registered ) {
+		if ( $registered['callback'] === $callback ) {
+			return $registered['priority'];
+		}
+	}
+
+	return false;
 }
 
 function has_action( $tag, $callback = false ) {


### PR DESCRIPTION
## Summary

- Restore BFAL's established priority-15 automatic admin stylesheet enqueue on Block Editor screens by removing PR #41's priority-14 suppression.
- Normalize only the exact `id="bfa-font-awesome-css"` and `id="bfa-font-awesome-v4-shim-css"` enqueued `LINK` tags to `crossorigin="anonymous"` through WordPress's `style_loader_tag` filter and `WP_HTML_Tag_Processor`.
- Preserve frontend loading, `add_editor_style()`, TinyMCE, the `media_buttons` picker, v4 shim CSS, stylesheet URLs and version query strings, singleton behavior, and all documented public methods.

## Publication gate

This correction must never be published again under `2.1.0-rc.1`. Browsers may already have cached an incompatible rc.1 stylesheet response without the required CORS response headers. Any future `2.1.0-rc.2` release preparation must update `Better_Font_Awesome_Library::VERSION` so the stylesheet `?ver=` URL changes before publication. This corrective PR intentionally does not bump the version or publish anything.

## Root cause

The Font Awesome 5.15.4 CDN varies its response by request mode. A GET without `Origin` returns neither ACAO nor `Vary: Origin`, while an anonymous CORS GET returns `Access-Control-Allow-Origin: *` and `Vary: Origin`. Chrome can cache the non-CORS response when the immutable stylesheet URL is first loaded normally, then reject that cached response when WordPress 7.1 later adds `crossorigin="anonymous"` in its isolated Block Editor flow.

PR #41 avoided the isolated request by suppressing BFAL's automatic Block Editor enqueue, but that removed the parent-document glyph dependency needed by legacy pickers on mixed Block Editor screens. This PR keeps WordPress's normal enqueue lifecycle and makes the first BFAL request use the same anonymous mode that the isolated editor requires. Font Awesome's [version 5 WordPress CDN example](https://docs-v5.fontawesome.com/web/use-with/wordpress/install-manually) also uses this attribute.

PR #42's delayed JavaScript loader is therefore unnecessary. This correction has no DOM polling, Gutenberg-private selectors, delayed link insertion, event interception, output buffering, media-processing override, CDN switch, or SRI addition.

## Deterministic coverage

- Both BFAL handles receive exactly one anonymous CORS attribute.
- The callback iterates every `LINK` and changes only the exact ID mapped to the current allowed BFAL handle.
- Unrelated preload or stylesheet links before and after the BFAL link remain byte-for-byte unchanged.
- If the expected BFAL ID is absent, the complete input remains byte-for-byte unchanged.
- An existing anonymous value stays idempotent and another value is normalized.
- Unrelated handles remain byte-for-byte unchanged.
- Unexpected or incomplete markup safely returns unchanged.
- The filter is registered once at priority 10 with two accepted arguments.
- Automatic priority-15 admin registration remains active on Block Editor screens.
- Direct registration and v4 enabled or disabled behavior remain compatible.
- PHPUnit uses WordPress test doubles and makes no live Font Awesome request.

## Verification

- PHPUnit: 109 tests, 429 assertions on PHP 7.4, 8.0, 8.1, 8.2, 8.3, and 8.4.
- PHPCS: pass.
- PHPStan: pass.
- Composer strict validation and audit: pass, no advisories.
- Tracked browser asset rebuild: clean.
- Shipped runtime asset audit: pass, 0 vulnerabilities.
- Production archive: two byte-identical builds, 18 production files, SHA-256 `143529bb486a60a1aa6550e3fbea3d54a9cf0840026ce79b03aa554ee23645c9`.

Browser verification used exact mapped source with all earlier media-processing experiments disabled. A priority-9 diagnostic `style_loader_tag` filter prepended an unrelated preload `LINK` before each BFAL stylesheet:

- WordPress 7.1, PHP 8.3, fresh Chromium context, v4 enabled: frontend first, then isolated Block Editor with one server-rendered `wp_editor()` meta box. Each diagnostic preload remained unchanged without a CORS attribute, while the following exact BFAL link received anonymous CORS. Both CDN CSS responses were 200 with ACAO `*` and `Vary: Origin`, both stylesheets were accepted and CSSOM-readable, the editor response had `Document-Isolation-Policy: isolate-and-credentialless`, no Font Awesome request failed, the parent picker glyph rendered, search returned results, insertion produced the expected shortcode, TinyMCE retained Font Awesome styling, and the block canvas received no BFAL stylesheet.
- The frontend-to-editor sequence was repeated in the same browser context. Both styles remained accepted with no Font Awesome failure.
- WordPress 7.1 Block Editor without a meta box: shortcode content remained editable and saved, parent CSS loaded with ACAO, and no BFAL CSS entered the block canvas.
- WordPress 7.1 with v4 disabled: only `all.css` loaded, anonymous CORS remained present, and the saved shortcode rendered on the frontend.
- Additional WordPress 7.1 stress fixture: two server-rendered TinyMCE instances and a client-created editor. All parent picker glyphs rendered and worked, and both server-rendered TinyMCE instances retained Font Awesome styling.
- WordPress 6.5 Classic Editor, v4 enabled: TinyMCE loaded both Font Awesome styles, the visible picker glyph rendered, search returned four matches, insertion created the expected shortcode, publishing succeeded, and the shortcode rendered on the frontend.
- BFA PR #52 exact head: candidate single-site suite passed 77 tests and 17,687 assertions with 4 expected skips; multisite passed 77 tests and 17,706 assertions with 1 expected skip. The BFA tracked worktree stayed clean.
- BFA generated packaged-plugin smoke on WordPress 7.1: corrected vendored source loaded, the Block Editor shortcode was preserved, both CSS responses returned 200 with ACAO, and the frontend shortcode rendered.

The root development-only npm audit continues to report the existing optional Grunt findings. The shipped runtime-assets audit is clean. A purely client-created `wp.editor.initialize()` TinyMCE instance does not inherit PHP `add_editor_style()` content CSS, which is existing WordPress behavior outside this request-mode correction. Its BFAL picker is rendered in the parent document, where the verified dependency is present and functional.

## Compatibility and rollback

The live Font Awesome metadata provider, transport, validation, cache, fallback, ownership, and request-path behavior are unchanged. There is no version bump and no public release action in this PR.

If this correction must be backed out before release, revert its merge commit. For a published release rollback, restore BFAL 2.0.3 in the consumer and redeploy the resulting Composer lockfile.
