### PR TITLE
Prepare BFAL 2.1.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 2.1.0-rc.2
+
+- Restored BFAL's normal static Font Awesome enqueue in the parent document, including WordPress 7.1 Block Editor screens that also contain traditional `wp_editor()` instances.
+- Added consistent anonymous CORS mode to the exact `bfa-font-awesome` and `bfa-font-awesome-v4-shim` stylesheet links. This keeps CDN responses usable by WordPress's isolated editor processing while preserving picker glyphs, TinyMCE styling, frontend CSS, and optional v4 compatibility.
+- Superseded the rc.1 Block Editor suppression behavior. The rc.2 runtime version produces distinct `?ver=2.1.0-rc.2` stylesheet URLs so incompatible one-year rc.1 browser cache entries cannot be reused.
+- Preserved the validated live Font Awesome Free 5.x metadata architecture, provider and fallback precedence, transport and integrity safeguards, first-caller singleton ownership, PHP 7.4 support, and existing public API.
+- Kept WordPress's normal enqueue lifecycle and the existing Font Awesome CDN. This candidate contains no delayed JavaScript stylesheet loader, DOM polling, event replay, bundled versioned Font Awesome CSS, or CDN change.
+
+To test the candidate after its tag is published:
+
+```console
+composer require mickey-kay/better-font-awesome-library:2.1.0-rc.2
+```
+
+To roll back to the previous stable release:
+
+```console
+composer require mickey-kay/better-font-awesome-library:2.0.3 --with-all-dependencies
+```
+
 ## 2.1.0-rc.1
 
 - Added a validated Font Awesome Free 5.x provider and release-record contract. Normal frontend, admin, editor, REST, and other request paths resolve only local provider, transient, or bundled fallback data.

--- a/README.md
+++ b/README.md
@@ -46,11 +46,15 @@ npm run build
 
 ## Release candidate and rollback ##
 
-After the `2.1.0-rc.1` tag is published, Composer users can test this exact candidate with an explicit stability-qualified constraint:
+After the `2.1.0-rc.2` tag is published, Composer users can test this exact candidate with an explicit stability-qualified constraint:
 
 ```
-composer require mickey-kay/better-font-awesome-library:2.1.0-rc.1
+composer require mickey-kay/better-font-awesome-library:2.1.0-rc.2
 ```
+
+The rc.2 candidate restores BFAL's normal static Font Awesome enqueue in the parent document and adds anonymous CORS mode only to BFAL's exact main and optional v4 shim stylesheet links. This fixes WordPress 7.1 Block Editor screens that also contain traditional `wp_editor()` instances while preserving picker glyphs, TinyMCE styling, frontend CSS, and the validated live Font Awesome Free 5.x metadata architecture. It supersedes the rc.1 Block Editor suppression behavior and contains no delayed JavaScript loader or CDN change.
+
+The runtime version change makes WordPress request `?ver=2.1.0-rc.2`. The correction must not be republished as rc.1 because browsers may retain incompatible one-year rc.1 stylesheet responses without the required CORS headers.
 
 To roll back, restore the last stable BFAL release and redeploy the resulting lockfile:
 
@@ -58,7 +62,7 @@ To roll back, restore the last stable BFAL release and redeploy the resulting lo
 composer require mickey-kay/better-font-awesome-library:2.0.3 --with-all-dependencies
 ```
 
-BFAL follows versions published from repository tags. The release candidate does not change the first-caller singleton ownership contract or introduce a post-construction registration API.
+BFAL follows versions published from repository tags. The release candidate does not change the first-caller singleton ownership contract, introduce a post-construction registration API, or alter metadata transport, validation, caching, fallback, or ownership behavior.
 
 ## Usage ##
 1. Copy the /better-font-awesome-library folder into your project.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,7 +7,7 @@ BFAL versions are published from repository tags and discovered automatically by
 Set the intended version and start from a clean checkout of its candidate commit:
 
 ```console
-RELEASE_VERSION=2.1.0-rc.1
+RELEASE_VERSION=2.1.0-rc.2
 git status --short
 composer install --no-interaction --prefer-dist
 composer validate --strict
@@ -25,7 +25,7 @@ Confirm that `Better_Font_Awesome_Library::VERSION`, both npm manifests, both np
 Create both verification archives only from the unpushed local tag. The tracked `.gitattributes` rules exclude tests, agent files, development configuration, development locks, build sources, and release tooling. Runtime Composer dependencies belong in `composer.json`; BFAL currently has no runtime Composer dependencies and the archive must not contain `vendor`.
 
 ```console
-RELEASE_VERSION=2.1.0-rc.1
+RELEASE_VERSION=2.1.0-rc.2
 ARTIFACT_PATH="better-font-awesome-library-${RELEASE_VERSION}.zip"
 VERIFICATION_ARTIFACT_PATH="better-font-awesome-library-${RELEASE_VERSION}-verification.zip"
 CHECKSUM_PATH="better-font-awesome-library-${RELEASE_VERSION}.sha256"
@@ -45,28 +45,30 @@ cat "$CHECKSUM_PATH"
 unzip -l "$ARTIFACT_PATH"
 ```
 
-The two archives must be byte-identical. Before publication, manually confirm the archive contains exactly 18 production files under the single `better-font-awesome-library-2.1.0-rc.1/` root directory. Confirm every required runtime file, the internal version surfaces, and the final SHA-256 checksum. Confirm tests, agent files, development dependencies, build sources, `node_modules`, and `vendor` are absent.
+The two archives must be byte-identical. Before publication, manually confirm the archive contains exactly 18 production files under the single `better-font-awesome-library-2.1.0-rc.2/` root directory. Confirm every required runtime file, the internal version surfaces, and the final SHA-256 checksum. Confirm tests, agent files, development dependencies, build sources, `node_modules`, and `vendor` are absent.
 
 ## Publish
 
-Recent stable BFAL releases use prefix-free, lightweight numeric tags. Release candidates also use a prefix-free tag, with `2.1.0-rc.1` as the first 2.1.0 candidate.
+Recent stable BFAL releases use prefix-free, lightweight numeric tags. Release candidates also use prefix-free tags. `2.1.0-rc.1` was the first 2.1.0 candidate, and `2.1.0-rc.2` is its successor.
+
+The rc.2 correction must never be published again under `2.1.0-rc.1`. Before publication, confirm `Better_Font_Awesome_Library::VERSION` is `2.1.0-rc.2` and that WordPress generates `?ver=2.1.0-rc.2` for both BFAL Font Awesome stylesheet handles. This distinct URL prevents browsers from reusing incompatible one-year rc.1 stylesheet responses without anonymous CORS headers.
 
 After the release-preparation pull request is approved and merged:
 
 1. Confirm the intended merged release commit and that the complete hosted PHP 7.4 through 8.4 and packaging matrix passed on that exact commit.
-2. Create the lightweight `2.1.0-rc.1` tag locally on the intended merge commit. Do not push it.
+2. Create the lightweight `2.1.0-rc.2` tag locally on the intended merge commit. Do not push it.
 3. Build the production archive twice from that exact unpushed local tag using the commands above.
 4. Confirm byte identity, all archive contents and exclusions, the single exact root directory, every version surface, and the final SHA-256 checksum. Create the `.sha256` file from the verified ZIP.
 5. Confirm the locally tagged commit is exactly the intended merge commit:
 
    ```console
-   test "$(git rev-parse '2.1.0-rc.1^{commit}')" = "$(git rev-parse origin/master)"
+   test "$(git rev-parse '2.1.0-rc.2^{commit}')" = "$(git rev-parse origin/master)"
    ```
 
 6. Only after every local-tag verification passes, push the tag. Pushing the tag is the publication boundary because Packagist may discover it immediately. Checks performed after this push confirm publication state but cannot prevent publication.
 7. Immediately create the GitHub prerelease and attach both the verified ZIP and its `.sha256` checksum file.
 8. Include the exact SHA-256 checksum directly in the GitHub prerelease notes as well as in the attached checksum file.
-9. Confirm that Packagist discovers `2.1.0-rc.1` with RC stability, points to the exact tagged merge commit, and that Composer installs the expected distribution contents.
+9. Confirm that Packagist discovers `2.1.0-rc.2` with RC stability, points to the exact tagged merge commit, and that Composer installs the expected distribution contents.
 
 Do not push the tag if the tagged commit, internal version, changelog, archive contents, archive root directory, byte comparison, or checksum record disagree.
 

--- a/better-font-awesome-library.php
+++ b/better-font-awesome-library.php
@@ -47,7 +47,7 @@ class Better_Font_Awesome_Library {
 	 *
 	 * @var    string
 	 */
-	const VERSION = '2.1.0-rc.1';
+	const VERSION = '2.1.0-rc.2';
 
 	/**
 	 * Font awesome GraphQL url.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-font-awesome-library",
-  "version": "2.1.0-rc.1",
+  "version": "2.1.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-font-awesome-library",
-      "version": "2.1.0-rc.1",
+      "version": "2.1.0-rc.2",
       "license": "GPL-2.0",
       "devDependencies": {
         "fontawesome-iconpicker": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-font-awesome-library",
   "description": "Better Font Awesome Library",
-  "version": "2.1.0-rc.1",
+  "version": "2.1.0-rc.2",
   "main": " ",
   "devDependencies": {
     "fontawesome-iconpicker": "3.2.0",

--- a/runtime-assets/package-lock.json
+++ b/runtime-assets/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-font-awesome-library-runtime-assets",
-  "version": "2.1.0-rc.1",
+  "version": "2.1.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-font-awesome-library-runtime-assets",
-      "version": "2.1.0-rc.1",
+      "version": "2.1.0-rc.2",
       "dependencies": {
         "fontawesome-iconpicker": "3.2.0"
       }

--- a/runtime-assets/package.json
+++ b/runtime-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-font-awesome-library-runtime-assets",
-  "version": "2.1.0-rc.1",
+  "version": "2.1.0-rc.2",
   "private": true,
   "description": "Audit manifest for third-party browser source copied into BFAL release archives.",
   "dependencies": {

--- a/tests/PublicCompatibilityTest.php
+++ b/tests/PublicCompatibilityTest.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/BfalTestCase.php';
 class PublicCompatibilityTest extends BfalTestCase {
 	public function test_public_constants_are_preserved() {
 		$this->assertSame( 'bfa', Better_Font_Awesome_Library::SLUG );
-		$this->assertSame( '2.1.0-rc.1', Better_Font_Awesome_Library::VERSION );
+		$this->assertSame( '2.1.0-rc.2', Better_Font_Awesome_Library::VERSION );
 		$this->assertSame( 'https://api.fontawesome.com', Better_Font_Awesome_Library::FONT_AWESOME_API_BASE_URL );
 		$this->assertSame( 'https://use.fontawesome.com/releases', Better_Font_Awesome_Library::FONT_AWESOME_CDN_BASE_URL );
 		$this->assertSame( 'inc/fallback-release-data.json', Better_Font_Awesome_Library::FALLBACK_RELEASE_DATA_PATH );
@@ -208,6 +208,8 @@ class PublicCompatibilityTest extends BfalTestCase {
 
 		$this->assertArrayHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_registered_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_registered_styles'] );
+		$this->assertSame( '2.1.0-rc.2', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome']['version'] );
+		$this->assertSame( '2.1.0-rc.2', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome-v4-shim']['version'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_enqueued_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_enqueued_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_inline_styles'] );


### PR DESCRIPTION
## Summary

- Prepare BFAL `2.1.0-rc.2` from exact PR #43 merge commit `a60ebd995c24f37d726ddd04156e0bcfe5070709`.
- Update the PHP runtime version, npm manifests and lock records, compatibility assertions, changelog, README, and release procedure consistently.
- Preserve the reviewed runtime implementation, live Font Awesome Free 5.x metadata architecture, public API, PHP 7.4 compatibility, normal WordPress enqueue lifecycle, existing CDN, and rollback to BFAL 2.0.3.

## Cache compatibility requirement

The rc.2 runtime version makes WordPress generate `?ver=2.1.0-rc.2` for both BFAL Font Awesome stylesheet handles. The PR adds compatibility assertions for both registration versions.

This correction must never be published again as `2.1.0-rc.1`. Browsers may retain incompatible one-year rc.1 stylesheet responses without ACAO. The distinct rc.2 URLs prevent those responses from being reused.

## Release notes

BFAL 2.1.0-rc.2:

- restores the normal static parent-document Font Awesome enqueue;
- adds anonymous CORS mode only to BFAL's exact main and optional v4 shim stylesheet links;
- fixes WordPress 7.1 Block Editor screens that also contain traditional `wp_editor()` instances;
- supersedes the rc.1 Block Editor suppression behavior;
- preserves the validated live metadata provider, integrity, cache, fallback, transport, and ownership architecture;
- contains no delayed JavaScript loader, DOM polling, event replay, bundled versioned Font Awesome CSS, or CDN change.

## Verification

- PR #43 merge tree `84b5f16e52004d4b8cb93fa3a611ca06efdd61d0` matched reviewed head `1d52ca9889cf8b42ab718e28115a4f4ea2289f0f` exactly.
- Every hosted check on the exact merge commit completed successfully before this branch was created.
- PHPUnit: 109 tests and 431 assertions on PHP 7.4, 8.0, 8.1, 8.2, 8.3, and 8.4.
- PHPCS and PHPStan: pass.
- Composer strict validation and audit: pass with no advisories.
- Browser asset rebuild: clean.
- Shipped runtime asset audit: pass with 0 vulnerabilities.
- Bundled fallback SHA-256: verified.
- `git diff --check`: pass.

## Browser verification

A fresh persistent Chromium profile first loaded exact published BFAL rc.1 commit `a05508043ea885fa611f559ab59cff73161b37d2` on the frontend. Its main and v4 shim `?ver=2.1.0-rc.1` responses had no ACAO and were retained in the profile. Without clearing the browser cache, the server switched to this exact local rc.2 candidate.

WordPress 7.1 then requested distinct `?ver=2.1.0-rc.2` main and shim URLs. Both returned HTTP 200 with ACAO `*` and `Vary: Origin`, were CSSOM-readable, and rendered parent picker glyphs. Picker search, shortcode insertion, TinyMCE styling, Block Editor shortcode preservation, frontend rendering, and repeated navigation passed. No rc.1 response was reused for an rc.2 URL.

Normal WordPress 7.1 Block Editor behavior with v4 disabled passed. WordPress 6.5 Classic Editor with v4 enabled passed picker visibility, glyph rendering, search, insertion, TinyMCE content styling, publication, and frontend shortcode rendering.

## BFA PR #52 integration

The exact BFA PR #52 head `1f0edcb7bf2b4ec800ebbe55f009cf7dcb570990` used an ignored runtime dependency override whose 16 BFAL production files matched this local candidate and generated package byte-for-byte. No BFA source or committed dependency file changed.

- Single site: 77 tests, 17,687 assertions, 4 expected skips.
- Multisite: 77 tests, 17,706 assertions, 1 expected skip.
- Block Editor, Classic Editor, frontend shortcode, and v4 enabled and disabled browser coverage: pass.
- Generated packaged-plugin smoke on WordPress 7.1: pass, including rc.2 source identity, Block Editor preservation, ACAO responses, and frontend rendering.
- BFA tracked worktree: clean.

## Provisional artifact

Two independent archives built from candidate commit `5fcc58ce5a1ed243cf35397975cb1097b87f549c` are byte-identical.

- Name: `better-font-awesome-library-2.1.0-rc.2.zip`
- Size: 120,916 bytes
- Files: 18 production files
- Root: `better-font-awesome-library-2.1.0-rc.2/`
- SHA-256: `0fa7718e48977c0a5c5a3eef274ba370338c3a7b522d49ce09d4f91938f8580a`
- Runtime Composer dependencies: none
- Development, test, agent, `node_modules`, and `vendor` paths: absent

This PR does not create or push a tag, publish a GitHub prerelease, update Packagist, or modify BFA.
