### PR TITLE
Prepare BFAL 2.1.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 2.1.0
+
+- Promoted the accepted 2.1.0-rc.2 implementation to stable with validated live Font Awesome Free 5.x metadata and no metadata HTTP on ordinary frontend, admin, editor, REST, or other request paths.
+- Preserved BFAL's asynchronous refresh contract and WordPress-owned orchestration in the Better Font Awesome consumer, including durable last-known-good storage, retry, locking, migration, and multisite behavior. BFAL retains its checksummed bundled fallback.
+- Preserved normal static Font Awesome stylesheet registration with anonymous CORS mode on BFAL's exact main and optional v4 shim handles. Block Editor, Classic Editor, hybrid `wp_editor()` screens, the TinyMCE picker, frontend rendering, and v4 compatibility remain supported.
+- Kept the validated provider contract, first-caller singleton ownership, live Font Awesome CDN architecture, PHP 7.4 compatibility, and public API unchanged from rc.2.
+- Recorded manual release-candidate acceptance of Better Font Awesome PR #52 at commit `3351b5e4c02aaf1694bdb7638cc663f398a5c7a4`. The accepted BFA candidate ZIP SHA-256 is `41e37852f70d1ee5d00cf3260a7da45e950f89755ee184e97a1a50a270333e15`.
+
+To install the stable release after its tag is published:
+
+```console
+composer require mickey-kay/better-font-awesome-library:2.1.0
+```
+
+To roll back to the previous stable release:
+
+```console
+composer require mickey-kay/better-font-awesome-library:2.0.3 --with-all-dependencies
+```
+
 ## 2.1.0-rc.2
 
 - Restored BFAL's normal static Font Awesome enqueue in the parent document, including WordPress 7.1 Block Editor screens that also contain traditional `wp_editor()` instances.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Better Font Awesome Library
 1. [Introduction](https://github.com/MickeyKay/better-font-awesome-library#introduction)
 1. [Features](https://github.com/MickeyKay/better-font-awesome-library#features)
 1. [Installation](https://github.com/MickeyKay/better-font-awesome-library#installation)
-1. [Release candidate and rollback](https://github.com/MickeyKay/better-font-awesome-library#release-candidate-and-rollback)
+1. [Stable release and rollback](https://github.com/MickeyKay/better-font-awesome-library#stable-release-and-rollback)
 1. [Changelog](https://github.com/MickeyKay/better-font-awesome-library/blob/master/CHANGELOG.md)
 1. [Usage](https://github.com/MickeyKay/better-font-awesome-library#usage)
 1. [Metadata lifecycle](https://github.com/MickeyKay/better-font-awesome-library#metadata-lifecycle)
@@ -34,7 +34,7 @@ The Better Font Awesome Library integrates validated Font Awesome Free 5.x metad
 ## Installation ##
 The Better Font Awesome Library should ideally be installed via Composer:
 ```
-composer require mickey-kay/better-font-awesome-library
+composer require mickey-kay/better-font-awesome-library:2.1.0
 ```
 
 Alternately, you can install the library manually, which can be useful for development and/or custom builds:
@@ -44,17 +44,19 @@ cd better-font-awesome-library
 npm run build
 ```
 
-## Release candidate and rollback ##
+## Stable release and rollback ##
 
-After the `2.1.0-rc.2` tag is published, Composer users can test this exact candidate with an explicit stability-qualified constraint:
+After the `2.1.0` tag is published, Composer users can install the exact stable release with:
 
 ```
-composer require mickey-kay/better-font-awesome-library:2.1.0-rc.2
+composer require mickey-kay/better-font-awesome-library:2.1.0
 ```
 
-The rc.2 candidate restores BFAL's normal static Font Awesome enqueue in the parent document and adds anonymous CORS mode only to BFAL's exact main and optional v4 shim stylesheet links. This fixes WordPress 7.1 Block Editor screens that also contain traditional `wp_editor()` instances while preserving picker glyphs, TinyMCE styling, frontend CSS, and the validated live Font Awesome Free 5.x metadata architecture. It supersedes the rc.1 Block Editor suppression behavior and contains no delayed JavaScript loader or CDN change.
+BFAL 2.1.0 provides validated live Font Awesome Free 5.x metadata with no metadata HTTP on ordinary requests. It supports consumer-controlled asynchronous refresh orchestration, durable last-known-good data in the Better Font Awesome consumer, and a checksummed bundled fallback. The accepted BFA integration supplies WordPress-owned scheduling, retry, locking, migration, and multisite behavior.
 
-The runtime version change makes WordPress request `?ver=2.1.0-rc.2`. The correction must not be republished as rc.1 because browsers may retain incompatible one-year rc.1 stylesheet responses without the required CORS headers.
+Normal static Font Awesome stylesheet registration uses anonymous CORS mode on BFAL's exact main and optional v4 shim handles. This preserves Block Editor, Classic Editor, hybrid `wp_editor()` screens, TinyMCE picker, frontend, and v4 compatibility behavior. The runtime version makes WordPress request `?ver=2.1.0` for those handles.
+
+Better Font Awesome PR #52 passed manual release-candidate acceptance at exact BFA commit `3351b5e4c02aaf1694bdb7638cc663f398a5c7a4`. The accepted BFA candidate ZIP SHA-256 is `41e37852f70d1ee5d00cf3260a7da45e950f89755ee184e97a1a50a270333e15`.
 
 To roll back, restore the last stable BFAL release and redeploy the resulting lockfile:
 
@@ -62,7 +64,7 @@ To roll back, restore the last stable BFAL release and redeploy the resulting lo
 composer require mickey-kay/better-font-awesome-library:2.0.3 --with-all-dependencies
 ```
 
-BFAL follows versions published from repository tags. The release candidate does not change the first-caller singleton ownership contract, introduce a post-construction registration API, or alter metadata transport, validation, caching, fallback, or ownership behavior.
+BFAL follows versions published from repository tags. The stable release does not change the first-caller singleton ownership contract, introduce a post-construction registration API, or alter metadata transport, validation, caching, fallback, or ownership behavior from the accepted rc.2 implementation.
 
 ## Usage ##
 1. Copy the /better-font-awesome-library folder into your project.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,7 +7,7 @@ BFAL versions are published from repository tags and discovered automatically by
 Set the intended version and start from a clean checkout of its candidate commit:
 
 ```console
-RELEASE_VERSION=2.1.0-rc.2
+RELEASE_VERSION=2.1.0
 git status --short
 composer install --no-interaction --prefer-dist
 composer validate --strict
@@ -25,7 +25,7 @@ Confirm that `Better_Font_Awesome_Library::VERSION`, both npm manifests, both np
 Create both verification archives only from the unpushed local tag. The tracked `.gitattributes` rules exclude tests, agent files, development configuration, development locks, build sources, and release tooling. Runtime Composer dependencies belong in `composer.json`; BFAL currently has no runtime Composer dependencies and the archive must not contain `vendor`.
 
 ```console
-RELEASE_VERSION=2.1.0-rc.2
+RELEASE_VERSION=2.1.0
 ARTIFACT_PATH="better-font-awesome-library-${RELEASE_VERSION}.zip"
 VERIFICATION_ARTIFACT_PATH="better-font-awesome-library-${RELEASE_VERSION}-verification.zip"
 CHECKSUM_PATH="better-font-awesome-library-${RELEASE_VERSION}.sha256"
@@ -45,30 +45,32 @@ cat "$CHECKSUM_PATH"
 unzip -l "$ARTIFACT_PATH"
 ```
 
-The two archives must be byte-identical. Before publication, manually confirm the archive contains exactly 18 production files under the single `better-font-awesome-library-2.1.0-rc.2/` root directory. Confirm every required runtime file, the internal version surfaces, and the final SHA-256 checksum. Confirm tests, agent files, development dependencies, build sources, `node_modules`, and `vendor` are absent.
+The two archives must be byte-identical. Before publication, manually confirm the archive contains exactly 18 production files under the single `better-font-awesome-library-2.1.0/` root directory. Confirm every required runtime file, the internal version surfaces, and the final SHA-256 checksum. Confirm tests, agent files, development dependencies, build sources, `node_modules`, and `vendor` are absent.
 
 ## Publish
 
-Recent stable BFAL releases use prefix-free, lightweight numeric tags. Release candidates also use prefix-free tags. `2.1.0-rc.1` was the first 2.1.0 candidate, and `2.1.0-rc.2` is its successor.
+Recent stable BFAL releases use prefix-free, lightweight numeric tags. Release candidates also use prefix-free tags. Stable `2.1.0` promotes the accepted `2.1.0-rc.2` implementation without runtime changes beyond the version constant and resulting stylesheet cache key.
 
-The rc.2 correction must never be published again under `2.1.0-rc.1`. Before publication, confirm `Better_Font_Awesome_Library::VERSION` is `2.1.0-rc.2` and that WordPress generates `?ver=2.1.0-rc.2` for both BFAL Font Awesome stylesheet handles. This distinct URL prevents browsers from reusing incompatible one-year rc.1 stylesheet responses without anonymous CORS headers.
+Before publication, confirm `Better_Font_Awesome_Library::VERSION` is `2.1.0` and that WordPress generates `?ver=2.1.0` for both BFAL Font Awesome stylesheet handles. The stable release must retain anonymous CORS mode on the exact `bfa-font-awesome` and `bfa-font-awesome-v4-shim` handles.
+
+Better Font Awesome PR #52 passed manual release-candidate acceptance at exact BFA commit `3351b5e4c02aaf1694bdb7638cc663f398a5c7a4`. The accepted BFA candidate ZIP SHA-256 is `41e37852f70d1ee5d00cf3260a7da45e950f89755ee184e97a1a50a270333e15`.
 
 After the release-preparation pull request is approved and merged:
 
 1. Confirm the intended merged release commit and that the complete hosted PHP 7.4 through 8.4 and packaging matrix passed on that exact commit.
-2. Create the lightweight `2.1.0-rc.2` tag locally on the intended merge commit. Do not push it.
+2. Create the lightweight `2.1.0` tag locally on the intended merge commit. Do not push it.
 3. Build the production archive twice from that exact unpushed local tag using the commands above.
 4. Confirm byte identity, all archive contents and exclusions, the single exact root directory, every version surface, and the final SHA-256 checksum. Create the `.sha256` file from the verified ZIP.
 5. Confirm the locally tagged commit is exactly the intended merge commit:
 
    ```console
-   test "$(git rev-parse '2.1.0-rc.2^{commit}')" = "$(git rev-parse origin/master)"
+   test "$(git rev-parse '2.1.0^{commit}')" = "$(git rev-parse origin/master)"
    ```
 
 6. Only after every local-tag verification passes, push the tag. Pushing the tag is the publication boundary because Packagist may discover it immediately. Checks performed after this push confirm publication state but cannot prevent publication.
-7. Immediately create the GitHub prerelease and attach both the verified ZIP and its `.sha256` checksum file.
-8. Include the exact SHA-256 checksum directly in the GitHub prerelease notes as well as in the attached checksum file.
-9. Confirm that Packagist discovers `2.1.0-rc.2` with RC stability, points to the exact tagged merge commit, and that Composer installs the expected distribution contents.
+7. Immediately create the GitHub release and attach both the verified ZIP and its `.sha256` checksum file.
+8. Include the exact SHA-256 checksum directly in the GitHub release notes as well as in the attached checksum file.
+9. Confirm that Packagist discovers stable `2.1.0`, points to the exact tagged merge commit, and that Composer installs the expected distribution contents.
 
 Do not push the tag if the tagged commit, internal version, changelog, archive contents, archive root directory, byte comparison, or checksum record disagree.
 

--- a/better-font-awesome-library.php
+++ b/better-font-awesome-library.php
@@ -47,7 +47,7 @@ class Better_Font_Awesome_Library {
 	 *
 	 * @var    string
 	 */
-	const VERSION = '2.1.0-rc.2';
+	const VERSION = '2.1.0';
 
 	/**
 	 * Font awesome GraphQL url.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-font-awesome-library",
-  "version": "2.1.0-rc.2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-font-awesome-library",
-      "version": "2.1.0-rc.2",
+      "version": "2.1.0",
       "license": "GPL-2.0",
       "devDependencies": {
         "fontawesome-iconpicker": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-font-awesome-library",
   "description": "Better Font Awesome Library",
-  "version": "2.1.0-rc.2",
+  "version": "2.1.0",
   "main": " ",
   "devDependencies": {
     "fontawesome-iconpicker": "3.2.0",

--- a/runtime-assets/package-lock.json
+++ b/runtime-assets/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-font-awesome-library-runtime-assets",
-  "version": "2.1.0-rc.2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-font-awesome-library-runtime-assets",
-      "version": "2.1.0-rc.2",
+      "version": "2.1.0",
       "dependencies": {
         "fontawesome-iconpicker": "3.2.0"
       }

--- a/runtime-assets/package.json
+++ b/runtime-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-font-awesome-library-runtime-assets",
-  "version": "2.1.0-rc.2",
+  "version": "2.1.0",
   "private": true,
   "description": "Audit manifest for third-party browser source copied into BFAL release archives.",
   "dependencies": {

--- a/tests/PublicCompatibilityTest.php
+++ b/tests/PublicCompatibilityTest.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/BfalTestCase.php';
 class PublicCompatibilityTest extends BfalTestCase {
 	public function test_public_constants_are_preserved() {
 		$this->assertSame( 'bfa', Better_Font_Awesome_Library::SLUG );
-		$this->assertSame( '2.1.0-rc.2', Better_Font_Awesome_Library::VERSION );
+		$this->assertSame( '2.1.0', Better_Font_Awesome_Library::VERSION );
 		$this->assertSame( 'https://api.fontawesome.com', Better_Font_Awesome_Library::FONT_AWESOME_API_BASE_URL );
 		$this->assertSame( 'https://use.fontawesome.com/releases', Better_Font_Awesome_Library::FONT_AWESOME_CDN_BASE_URL );
 		$this->assertSame( 'inc/fallback-release-data.json', Better_Font_Awesome_Library::FALLBACK_RELEASE_DATA_PATH );
@@ -208,8 +208,8 @@ class PublicCompatibilityTest extends BfalTestCase {
 
 		$this->assertArrayHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_registered_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_registered_styles'] );
-		$this->assertSame( '2.1.0-rc.2', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome']['version'] );
-		$this->assertSame( '2.1.0-rc.2', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome-v4-shim']['version'] );
+		$this->assertSame( '2.1.0', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome']['version'] );
+		$this->assertSame( '2.1.0', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome-v4-shim']['version'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_enqueued_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_enqueued_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_inline_styles'] );


### PR DESCRIPTION
## Summary

Prepare Better Font Awesome Library 2.1.0 stable by promoting the published and accepted 2.1.0-rc.2 implementation. This changes established version surfaces and release documentation only.

## Exact revision

- Base commit: `b9b7da9c066572de10b18dcca9679ca8cc2a70c1`
- Base tree: `885cb17038c8f9f966628f208e206aceafbac623`
- Head commit: `3bed741d08cd377452f41a2f98fb2fb9a13de36b`
- Head tree: `179db63ff6e1a2c5e48255980564a0961ca5fce9`
- Published `2.1.0-rc.2` tag and `origin/master` were verified at the exact base commit with identical trees and an empty diff before this branch was created.

## Changed files and version surfaces

- `better-font-awesome-library.php`: `Better_Font_Awesome_Library::VERSION` is `2.1.0`, producing `?ver=2.1.0` for both BFAL Font Awesome handles.
- `package.json`: root npm version is `2.1.0`.
- `package-lock.json`: top-level and root-package versions are `2.1.0`.
- `runtime-assets/package.json`: runtime audit manifest version is `2.1.0`.
- `runtime-assets/package-lock.json`: top-level and root-package versions are `2.1.0`.
- `tests/PublicCompatibilityTest.php`: public constant and both stylesheet cache-key assertions expect `2.1.0`.
- `CHANGELOG.md`: stable release notes, installation, rollback, and BFA acceptance evidence.
- `README.md`: stable installation, behavior summary, BFA acceptance evidence, and rollback.
- `RELEASING.md`: stable tag, artifact, publication, checksum, and Packagist procedure.

`composer.json` remains versionless so Composer derives the package version from its VCS tag.

## Runtime proof

After replacing only `const VERSION = '2.1.0-rc.2';` with `const VERSION = '2.1.0';` in the base version of `better-font-awesome-library.php`, it is byte-identical to the head file. There are no changes under `inc/`, `css/`, `js/`, or `lib/`, and no Composer manifest or dependency-lock changes. Metadata, transport, validation, provider, cache, fallback, ownership, CORS targeting, editor, picker, shortcode, and frontend behavior are unchanged.

## Stable scope

The accepted release provides validated live Font Awesome Free 5.x metadata, asynchronous WordPress-owned refresh orchestration in Better Font Awesome, durable last-known-good storage, checksummed bundled fallback, retry, locking, migration, multisite support, and zero metadata HTTP on ordinary requests. Static styles keep anonymous CORS mode on BFAL's exact main and optional v4 shim handles across Block Editor, Classic Editor, hybrid `wp_editor()`, picker, and frontend contexts.

This PR does not claim Font Awesome 6, Font Awesome 7, Font Awesome Pro, a dedicated BFA block, locally hosted Font Awesome assets, or any new runtime capability.

## BFA acceptance evidence

- Better Font Awesome PR #52 candidate commit: `3351b5e4c02aaf1694bdb7638cc663f398a5c7a4`
- Accepted BFA candidate ZIP SHA-256: `41e37852f70d1ee5d00cf3260a7da45e950f89755ee184e97a1a50a270333e15`

## Validation

- PHPUnit on PHP 7.4, 8.0, 8.1, 8.2, 8.3, and 8.4: 109 tests and 431 assertions passed on every version.
- PHPCS: passed.
- PHPStan: passed with no errors using a 1 GB analysis limit after the local 128 MB and 512 MB worker limits proved insufficient.
- `composer validate --strict`: passed.
- `composer audit`: no security vulnerability advisories.
- Clean `npm run build`: passed and produced no tracked diff under `css/`, `js/`, or `lib/`.
- `npm run audit:runtime-assets`: exact asset coverage verified and zero runtime vulnerabilities.
- Bundled fallback checksum: verified as `f5087d6c4a79727e74a9fc43fea3fca02fc2a0587d63b6aedc5a6a23daa4ad98`.
- `git diff --check`: passed.
- Hosted checks on exact head `3bed741d08cd377452f41a2f98fb2fb9a13de36b`: all 15 passed, including push and pull-request PHP 7.4 through 8.4 matrices, both quality and packaging jobs, and GitGuardian Security Checks.

The root development npm audit still reports the existing development-only findings. They are outside this version-only promotion and the shipped runtime asset audit is clean.

## Provisional production archive

- Source: exact head commit `3bed741d08cd377452f41a2f98fb2fb9a13de36b`
- Root: `better-font-awesome-library-2.1.0/`
- Production files: exactly 18
- Size: 121188 bytes
- SHA-256: `ba1698353cf0f4ee9fcdb0d951101509631235d14e67cc28da4f998cff17e821`
- Two independent `git archive` builds: byte-identical
- Runtime Composer dependencies: zero
- Required runtime files, licenses, notices, fallback metadata, and checksum: present
- Tests, agent files, repository files, release tooling, development manifests and locks, build sources, `node_modules`, and `vendor`: absent

This checksum is provisional. Publication must rebuild twice from the exact unpushed local tag on the eventual merge commit and record that final checksum.

## Controlled publication after approval and merge

1. Verify the exact merge commit and all hosted checks.
2. Create an unpushed local lightweight `2.1.0` tag on that merge commit.
3. Build two archives from that exact local tag.
4. Verify byte identity, exact contents and exclusions, the root directory, all versions, commit identity, and SHA-256.
5. Confirm the local tag points exactly to the intended merge commit.
6. Only after every local check passes, push the tag. The tag push is the Packagist publication boundary.
7. Immediately create the GitHub release with the verified ZIP and `.sha256` attachment.
8. Include the exact checksum in the GitHub release notes.
9. Confirm Packagist exposes stable 2.1.0 at the exact commit and Composer installs the expected distribution.

Rollback remains stable BFAL `2.0.3`.

No tag, GitHub release, Packagist publication, merge, or BFA modification is part of this PR preparation.
