### PR TITLE
Add Font Awesome 7 runtime channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ The following arguments can be used to initialize the library using `Better_Font
 
 The selected 7.x channel follows completely validated 7.x releases only. It will not update across a future Font Awesome major.
 
+An unsupported first-caller channel value fails closed. BFAL records a sanitized `bfa_channel_unsupported` error and returns no release metadata or stylesheet URLs. Because first-caller ownership remains immutable, a later caller cannot replace that invalid selection.
+
 These metadata collaborators are initialization arguments and therefore follow the same first-caller ownership contract. They cannot be added or replaced through a later `get_instance()` call.
 
 ### Deprecated
@@ -266,7 +268,7 @@ The object has the following public methods:
 (array) Returns the validated internal record with `schema_version`, `channel`, `edition`, `source`, and the compatibility-preserving `release` array.
 
 #### get_release_channel() ####
-(string) Returns the immutable selected Font Awesome channel, `7.x` by default or explicit `5.x`.
+(string) Returns the immutable selected Font Awesome channel, `7.x` by default or explicit `5.x`. Returns an empty string when an unsupported first-caller value has caused the runtime to fail closed.
 
 #### request_release_data_refresh() ####
 Requests asynchronous refresh scheduling through the configured callback or `bfa_release_data_refresh_requested` action. This method performs no remote transport.
@@ -283,7 +285,7 @@ Requests asynchronous refresh scheduling through the configured callback or `bfa
 ### Deprecated
 
 #### get_api_data() (2.0.0) ####
-_The library no longe relies on the jsDelivr CDN._
+_This deprecated method is no longer used for ordinary release discovery. The explicit Font Awesome 7 refresh worker uses exact-version jsDelivr files only for mandatory cross-provider byte validation._
 
 (object) Returns version data for the remote jsDelivr CDN (uses [jsDelivr API](https://github.com/jsdelivr/api)). Includes all available versions and latest version.
 
@@ -326,7 +328,7 @@ Applied to arguments passed to the explicit metadata refresh request. TLS verifi
 * `$wp_remote_get_args` (array)
 
 #### bfa_font_awesome_release_channel ####
-Applied once while the first singleton caller's release channel is initialized. BFAL accepts only `5.x` and `7.x`. The resolved value is immutable for the lifetime of that instance, so later calls and later filter changes cannot switch metadata or assets.
+Applied once while the first singleton caller's release channel is initialized. BFAL accepts only `5.x` and `7.x`. The resolved value is immutable for the lifetime of that instance, so later calls and later filter changes cannot switch metadata or assets. An unsupported result fails closed with no release metadata or stylesheet URLs.
 
 **Parameters**
 
@@ -391,7 +393,7 @@ Applied to the boolean that determines whether or not to suppress all Font Aweso
 ## Actions ##
 
 #### bfa_release_data_refresh_requested ####
-Fires once per BFAL request when no valid provider or transient value is available and bundled fallback data is selected. Handlers receive the `5.x` channel and BFAL instance. Handlers must schedule asynchronous work and return promptly.
+Fires once per BFAL request when no valid provider or transient value is available and bundled fallback data is selected. Handlers receive the immutable selected channel (`5.x` or `7.x`) and BFAL instance. Handlers must schedule asynchronous work and return promptly.
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Better Font Awesome Library
 1. [Features](https://github.com/MickeyKay/better-font-awesome-library#features)
 1. [Installation](https://github.com/MickeyKay/better-font-awesome-library#installation)
 1. [Stable release and rollback](https://github.com/MickeyKay/better-font-awesome-library#stable-release-and-rollback)
-1. [Font Awesome 7 and the future 3.0.0 release](https://github.com/MickeyKay/better-font-awesome-library#font-awesome-7-and-the-future-300-release)
+1. [Font Awesome 7 and the next major BFAL release](https://github.com/MickeyKay/better-font-awesome-library#font-awesome-7-and-the-next-major-bfal-release)
 1. [Changelog](https://github.com/MickeyKay/better-font-awesome-library/blob/master/CHANGELOG.md)
 1. [Usage](https://github.com/MickeyKay/better-font-awesome-library#usage)
 1. [Metadata lifecycle](https://github.com/MickeyKay/better-font-awesome-library#metadata-lifecycle)
@@ -21,7 +21,7 @@ Better Font Awesome Library
 1. [Credits](https://github.com/MickeyKay/better-font-awesome-library#credits)
 
 ## Introduction ##
-The Better Font Awesome Library integrates validated Font Awesome Free metadata and channel-coupled assets into WordPress projects, along with CSS registration, a shortcode, and a TinyMCE icon shortcode generator. Consumers can supply locally resolved metadata and schedule asynchronous refresh work without making normal requests wait on the Font Awesome service. Tagged BFAL 2.x releases use Font Awesome 5.x; the future BFAL 3.x runtime defaults to Font Awesome 7.x.
+The Better Font Awesome Library integrates validated Font Awesome Free metadata and channel-coupled assets into WordPress projects, along with CSS registration, a shortcode, and a TinyMCE icon shortcode generator. Consumers can supply locally resolved metadata and schedule asynchronous refresh work without making normal requests wait on the Font Awesome service. Tagged BFAL 2.x releases use Font Awesome 5.x; the next major BFAL release defaults to Font Awesome 7.x.
 
 ## Features ##
 * Returns validated local metadata immediately from a provider, transient, or bundled fallback.
@@ -67,11 +67,11 @@ composer require mickey-kay/better-font-awesome-library:2.0.3 --with-all-depende
 
 BFAL follows versions published from repository tags. The stable release does not change the first-caller singleton ownership contract, introduce a post-construction registration API, or alter metadata transport, validation, caching, fallback, or ownership behavior from the accepted rc.2 implementation.
 
-## Font Awesome 7 and the future 3.0.0 release ##
+## Font Awesome 7 and the next major BFAL release ##
 
-The Font Awesome 7 runtime on the development branch is foundation for BFAL 3.0.0. It must not be published as a BFAL 2.x update. Existing tagged BFAL 2.x releases remain the Font Awesome 5-compatible line. A separate reviewed release-preparation change must update the BFAL version surfaces and compatibility documentation before this work is published as 3.0.0.
+The Font Awesome 7 runtime changes the default Font Awesome major and must not be published as a BFAL 2.x update. Existing tagged BFAL 2.x releases remain the Font Awesome 5-compatible line. A separate reviewed release-preparation change must assign the appropriate next major BFAL version and update its version surfaces and compatibility documentation before publication.
 
-BFAL 3.x defaults to the `7.x` release channel when the first caller supplies no `release_channel` argument. Explicit `release_channel => '7.x'` is identical to that default. Consumers that deliberately require the legacy runtime can select `release_channel => '5.x'`. The first caller owns this immutable selection, just like every other initialization argument.
+The next major BFAL release defaults to the `7.x` release channel when the first caller supplies no `release_channel` argument. Explicit `release_channel => '7.x'` is identical to that default. Consumers that deliberately require the legacy runtime can select `release_channel => '5.x'`. The first caller owns this immutable selection, just like every other initialization argument.
 
 The 7.x channel validates and loads the packaged Font Awesome Free 7.3.1 baseline immediately. Its CSS and WOFF2 URLs are derived from the BFAL installation URL, so activation needs no HTTP request, cron run, migration, pending state, or setting. Normal frontend, admin, editor, REST, shortcode, picker, and getter paths perform no metadata HTTP.
 
@@ -190,7 +190,7 @@ The following arguments can be used to initialize the library using `Better_Font
 #### $args['release_channel'] ####
 
 (string) Immutable Font Awesome Free major channel selected by the first singleton caller.
-* `7.x` (default for the future BFAL 3.x release line)
+* `7.x` (default for the next major BFAL release)
 * `5.x` - explicit legacy behavior compatible with the BFAL 2.x runtime
 
 The selected 7.x channel follows completely validated 7.x releases only. It will not update across a future Font Awesome major.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Better Font Awesome Library
 1. [Features](https://github.com/MickeyKay/better-font-awesome-library#features)
 1. [Installation](https://github.com/MickeyKay/better-font-awesome-library#installation)
 1. [Stable release and rollback](https://github.com/MickeyKay/better-font-awesome-library#stable-release-and-rollback)
+1. [Font Awesome 7 and the future 3.0.0 release](https://github.com/MickeyKay/better-font-awesome-library#font-awesome-7-and-the-future-300-release)
 1. [Changelog](https://github.com/MickeyKay/better-font-awesome-library/blob/master/CHANGELOG.md)
 1. [Usage](https://github.com/MickeyKay/better-font-awesome-library#usage)
 1. [Metadata lifecycle](https://github.com/MickeyKay/better-font-awesome-library#metadata-lifecycle)
@@ -20,15 +21,15 @@ Better Font Awesome Library
 1. [Credits](https://github.com/MickeyKay/better-font-awesome-library#credits)
 
 ## Introduction ##
-The Better Font Awesome Library integrates validated Font Awesome Free 5.x metadata and version-coupled CDN assets into WordPress projects, along with CSS registration, a shortcode, and a TinyMCE icon shortcode generator. Consumers can supply locally resolved metadata and schedule asynchronous refresh work without making normal requests wait on the Font Awesome service.
+The Better Font Awesome Library integrates validated Font Awesome Free metadata and channel-coupled assets into WordPress projects, along with CSS registration, a shortcode, and a TinyMCE icon shortcode generator. Consumers can supply locally resolved metadata and schedule asynchronous refresh work without making normal requests wait on the Font Awesome service. Tagged BFAL 2.x releases use Font Awesome 5.x; the future BFAL 3.x runtime defaults to Font Awesome 7.x.
 
 ## Features ##
 * Returns validated local metadata immediately from a provider, transient, or bundled fallback.
 * Exposes an explicit, bounded refresh operation for consumer-controlled asynchronous workers.
 * Generates an easy-to-use [PHP object](#the-better-font-awesome-library-object) that contains all relevant info for the version of Font Awesome you're using, including: version, stylesheet URL, array of available icons, and prefix used (`icon` or `fa`).
-* Loads exact-version Font Awesome Free 5 CSS and webfonts from the Font Awesome CDN.
+* Loads the exact assets coupled to the immutable selected Font Awesome Free channel.
 * Includes a TinyMCE drop-down shortcode generator.
-* Includes checksummed Font Awesome Free 5.14.0 metadata as a validated fallback. You can specify validated custom fallback JSON with the `bfa_fallback_release_data_path` filter.
+* Includes validated Font Awesome Free 7.3.1 CSS, WOFF2, and metadata as the immediate default fallback, plus the established Font Awesome Free 5.14.0 metadata fallback for explicit 5.x consumers. The `bfa_fallback_release_data_path` filter remains available for the 5.x fallback.
 * Preserves the established `bfa-release-data` transient for backward compatibility.
 
 ## Installation ##
@@ -66,6 +67,18 @@ composer require mickey-kay/better-font-awesome-library:2.0.3 --with-all-depende
 
 BFAL follows versions published from repository tags. The stable release does not change the first-caller singleton ownership contract, introduce a post-construction registration API, or alter metadata transport, validation, caching, fallback, or ownership behavior from the accepted rc.2 implementation.
 
+## Font Awesome 7 and the future 3.0.0 release ##
+
+The Font Awesome 7 runtime on the development branch is foundation for BFAL 3.0.0. It must not be published as a BFAL 2.x update. Existing tagged BFAL 2.x releases remain the Font Awesome 5-compatible line. A separate reviewed release-preparation change must update the BFAL version surfaces and compatibility documentation before this work is published as 3.0.0.
+
+BFAL 3.x defaults to the `7.x` release channel when the first caller supplies no `release_channel` argument. Explicit `release_channel => '7.x'` is identical to that default. Consumers that deliberately require the legacy runtime can select `release_channel => '5.x'`. The first caller owns this immutable selection, just like every other initialization argument.
+
+The 7.x channel validates and loads the packaged Font Awesome Free 7.3.1 baseline immediately. Its CSS and WOFF2 URLs are derived from the BFAL installation URL, so activation needs no HTTP request, cron run, migration, pending state, or setting. Normal frontend, admin, editor, REST, shortcode, picker, and getter paths perform no metadata HTTP.
+
+An explicit 7.x background refresh discovers only the latest supported 7.x Free release. A same-version check uses one Font Awesome metadata request. A genuinely newer candidate is limited to 18 total requests, 4 MiB of response bodies, and 30 seconds. It must pass exact npm publication, cdnjs and jsDelivr byte comparison, CSS SRI, required WOFF2, CSS-to-font reference, family, style, icon, and alias validation. The worker returns one complete schema-2 record or a sanitized `WP_Error`; BFAL does not persist 7.x refresh results. Consumer code owns last-known-good storage, scheduling, locking, retry, and freshness policy.
+
+The 7.x channel never crosses automatically to Font Awesome 8. Supporting another Font Awesome major requires a separately reviewed BFAL compatibility release.
+
 ## Usage ##
 1. Copy the /better-font-awesome-library folder into your project.
 
@@ -92,6 +105,7 @@ add_action( 'init', 'my_prefix_load_bfa' );
       'load_tinymce_plugin' => true,
       'release_data_provider' => null,
       'release_data_refresh_callback' => null,
+      'release_channel' => '7.x',
     );
 
     // Initialize the Better Font Awesome Library.
@@ -107,22 +121,22 @@ The Better Font Awesome Library is designed to work in conjunction with the [Bet
 1. Initialize later so Better Font Awesome reaches the singleton first. Your later arguments are ignored, and Better Font Awesome owns the configuration. This is the default behavior shown above by initializing on the `init` hook at priority `10`.
 1. Initialize earlier to take ownership. Better Font Awesome's later arguments are ignored and cannot override yours.
 
-This first-caller contract is intentional and applies to every initialization argument, including the release-data provider and refresh callback. Hook priority determines ownership. BFAL does not provide post-construction registration, reset, mutation, or ownership transfer.
+This first-caller contract is intentional and applies to every initialization argument, including the release channel, release-data provider, and refresh callback. Hook priority determines ownership. BFAL does not provide post-construction registration, reset, mutation, or ownership transfer.
 
 ## Metadata lifecycle ##
 
-Normal frontend, admin, editor, REST, and cron-triggering requests never call the Font Awesome metadata service synchronously. BFAL resolves release data in this order:
+Normal frontend, admin, editor, REST, and cron-triggering requests never call the Font Awesome metadata service synchronously. BFAL resolves release data only for the immutable channel selected during first-caller initialization, in this order:
 
 1. The per-request validated value.
 2. An optional `release_data_provider` callable that returns already-resolved local data.
 3. A validated value from the established `bfa-release-data` transient.
-4. The checksummed and validated bundled Font Awesome Free 5.14.0 fallback.
+4. The validated bundled fallback for the selected channel: Font Awesome Free 7.3.1 for `7.x`, or the established Font Awesome Free 5.14.0 fallback for explicit `5.x`.
 
 When BFAL reaches the fallback, it invokes `release_data_refresh_callback` once if configured. Otherwise it fires `bfa_release_data_refresh_requested` with the supported channel and library instance. The handler must only schedule work and return promptly. Scheduling, locking, durable last-known-good persistence, retry backoff, jitter, and freshness policy belong to the consumer.
 
 A provider may return a release array or a declared BFAL release record. Declared records must use the exact supported `schema_version`, `channel`, and `edition`, an allowed `source`, and a fully valid nested release. BFAL rejects mismatches rather than discarding or normalizing them.
 
-An asynchronous worker can call `refresh_release_data()`. That explicit operation requests the `5.x` Free channel with TLS verification, no redirects, a timeout of at most five seconds, and a response limit of 2 MiB. It stores the established transient shape only after the entire release record validates. It returns the validated release array on success or a sanitized `WP_Error` on failure.
+An asynchronous worker can call `refresh_release_data()`. For explicit `5.x`, the established operation retains its existing validated transient behavior and release-array return value. For `7.x`, one bounded attempt returns a complete validated schema-2 record or a sanitized `WP_Error` and performs no BFAL persistence. Both paths require TLS, reject redirects and unsafe URLs, and leave the prior validated data untouched on failure.
 
 The Font Awesome API and CDN are external services. Consumers should document when they contact those services and apply the consent, privacy, scheduling, and persistence policy appropriate to their application.
 
@@ -173,14 +187,22 @@ The following arguments can be used to initialize the library using `Better_Font
 
 (callable|null) Optional callback invoked once when BFAL falls back to bundled data. It receives the supported channel and BFAL instance and must schedule asynchronous work rather than perform transport inline.
 
+#### $args['release_channel'] ####
+
+(string) Immutable Font Awesome Free major channel selected by the first singleton caller.
+* `7.x` (default for the future BFAL 3.x release line)
+* `5.x` - explicit legacy behavior compatible with the BFAL 2.x runtime
+
+The selected 7.x channel follows completely validated 7.x releases only. It will not update across a future Font Awesome major.
+
 These metadata collaborators are initialization arguments and therefore follow the same first-caller ownership contract. They cannot be added or replaced through a later `get_instance()` call.
 
 ### Deprecated
 
 #### $args['version'] (2.0.0) ####
-_The library no longer selects a version through this argument. Validated Font Awesome Free 5.x metadata now comes from the configured local provider, compatibility transient, or bundled fallback._
+_The library no longer selects a version through this argument. Validated Font Awesome Free metadata comes from the configured local provider, compatibility transient, or bundled fallback for the immutable selected channel._
 
-(string) Retained for compatibility. Supplied values are ignored because the validated release record selects the supported 5.x version and its coupled assets.
+(string) Retained for compatibility. Supplied values are ignored because the validated release record selects the supported version within the immutable major channel and its coupled assets.
 
 #### $args['minified'] (2.0.0) ####
 _The library now always defaults to minified CSS._
@@ -235,7 +257,7 @@ The object has the following public methods:
 (array) Returns an associative array of icon hex values (index, e.g. \f000) and unprefixed icon names (values, e.g. rocket) for all available icons in the active Font Awesome version.
 
 #### get_release_icons() ####
-(array) Returns icon data in the exact format provided by the Font Awesome GraphQL API.
+(array) Returns icon data in BFAL's established public icon shape. Schema-2 family and style metadata is adapted without changing that shape.
 
 #### get_release_assets() ####
 (array) Returns validated Free release asset data for the selected Font Awesome version.
@@ -244,7 +266,7 @@ The object has the following public methods:
 (array) Returns the validated internal record with `schema_version`, `channel`, `edition`, `source`, and the compatibility-preserving `release` array.
 
 #### get_release_channel() ####
-(string) Returns the supported Font Awesome channel, currently `5.x`.
+(string) Returns the immutable selected Font Awesome channel, `7.x` by default or explicit `5.x`.
 
 #### request_release_data_refresh() ####
 Requests asynchronous refresh scheduling through the configured callback or `bfa_release_data_refresh_requested` action. This method performs no remote transport.
@@ -304,7 +326,7 @@ Applied to arguments passed to the explicit metadata refresh request. TLS verifi
 * `$wp_remote_get_args` (array)
 
 #### bfa_font_awesome_release_channel ####
-Applied to the release channel used by explicit refresh. BFAL currently accepts only `5.x`; unsupported filtered values fail before transport.
+Applied once while the first singleton caller's release channel is initialized. BFAL accepts only `5.x` and `7.x`. The resolved value is immutable for the lifetime of that instance, so later calls and later filter changes cannot switch metadata or assets.
 
 **Parameters**
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,31 +2,30 @@
 
 BFAL versions are published from repository tags and discovered automatically by Packagist. Do not add a `version` field to `composer.json`.
 
-The active Font Awesome 7 runtime foundation changes the implicit channel default and therefore must not be published on the BFAL 2.x release line. BFAL 2.x remains the Font Awesome 5-compatible line. Before publication, prepare and review a separate BFAL 3.0.0 release change that updates every version surface, compatibility note, archive expectation, and consumer integration requirement. Do not publish the Font Awesome 7 runtime under a 2.x tag.
+Changing the default Font Awesome major is a public compatibility change. Publish it only through an appropriately versioned, separately reviewed BFAL release. Never publish a default-major change as a compatible update to the preceding BFAL release line.
 
-For development-only archive verification, this foundation adds `inc/class-bfa-release-data-v2-refresher.php` to the 34-file BFAL 2.1.0 inventory, producing 35 regular production files. The future 3.0.0 release-preparation change must replace the historical 2.1.0 archive instructions below with the final reviewed version, root directory, inventory, and checksum expectations.
+Exact candidate commits, archive counts, checksums, and consumer acceptance evidence belong in the release-preparation pull request and release record. Keep this procedure parameterized so it remains valid for later releases.
 
-## Prepare and verify
+## Update the bundled Font Awesome fallback
 
-When updating the Font Awesome 7 fallback, select one exact official
-npm version and regenerate it with:
+When updating the Font Awesome 7 fallback, select one exact approved official npm version:
 
 ```console
+FONT_AWESOME_VERSION="<approved exact 7.x version>"
 npm ci
-npm run generate:font-awesome-7-fallback -- 7.3.1
+npm run generate:font-awesome-7-fallback -- "$FONT_AWESOME_VERSION"
 npm run verify:font-awesome-7-fallback
 git diff --exit-code inc/font-awesome-7-fallback
 ```
 
-Run the generation command a second time and require an empty diff to verify
-byte-identical output. The generator verifies the npm registry identity and
-tarball integrity before extracting its fixed allowlist. The `scripts`
-directory and root Node manifests are excluded from production archives.
+Run the generation command a second time and require an empty diff to verify byte-identical output. The generator verifies npm registry identity and tarball integrity before extracting its fixed allowlist. The `scripts` directory and root Node manifests are excluded from production archives.
 
-Set the intended version and start from a clean checkout of its candidate commit:
+## Prepare and verify
+
+Set the intended BFAL version and start from a clean checkout of its candidate commit:
 
 ```console
-RELEASE_VERSION=2.1.0
+RELEASE_VERSION="<version>"
 git status --short
 composer install --no-interaction --prefer-dist
 composer validate --strict
@@ -34,17 +33,19 @@ composer audit
 composer check
 npm run build
 npm run audit:runtime-assets
+npm run verify:font-awesome-7-fallback
 git diff --exit-code
 ```
 
-Confirm that `Better_Font_Awesome_Library::VERSION`, both npm manifests, both npm lockfile root records, the compatibility test, and the changelog use the same release version. `composer.json` intentionally has no version field because Composer derives the package version from the tag.
+Confirm that `Better_Font_Awesome_Library::VERSION`, both npm manifests, both npm lockfile root records, the compatibility test, and the changelog use the intended release version. `composer.json` intentionally has no version field because Composer derives the package version from the tag.
 
 ## Build the production archive
 
-Create both verification archives only from the unpushed local tag. The tracked `.gitattributes` rules exclude tests, agent files, development configuration, development locks, build sources, and release tooling. Runtime Composer dependencies belong in `composer.json`; BFAL currently has no runtime Composer dependencies and the archive must not contain `vendor`.
+Record the reviewed production file count in the release-preparation evidence, then create two verification archives only from the unpushed local tag. The tracked `.gitattributes` rules exclude tests, agent files, development configuration, development locks, build sources, and release tooling. Runtime Composer dependencies belong in `composer.json`. If BFAL has no runtime Composer dependencies, the archive must not contain `vendor`.
 
 ```console
-RELEASE_VERSION=2.1.0
+RELEASE_VERSION="<version>"
+EXPECTED_FILE_COUNT="<reviewed production file count>"
 ARTIFACT_PATH="better-font-awesome-library-${RELEASE_VERSION}.zip"
 VERIFICATION_ARTIFACT_PATH="better-font-awesome-library-${RELEASE_VERSION}-verification.zip"
 CHECKSUM_PATH="better-font-awesome-library-${RELEASE_VERSION}.sha256"
@@ -60,43 +61,36 @@ git archive \
   "$RELEASE_VERSION"
 cmp "$ARTIFACT_PATH" "$VERIFICATION_ARTIFACT_PATH"
 shasum -a 256 "$ARTIFACT_PATH" > "$CHECKSUM_PATH"
+ARCHIVE_FILE_COUNT="$(unzip -Z1 "$ARTIFACT_PATH" | awk '! /\/$/ { count++ } END { print count + 0 }')"
+test "$ARCHIVE_FILE_COUNT" = "$EXPECTED_FILE_COUNT"
 cat "$CHECKSUM_PATH"
 unzip -l "$ARTIFACT_PATH"
 ```
 
-The two archives must be byte-identical. Before publication, manually confirm the archive contains exactly 34 regular production files under the single `better-font-awesome-library-2.1.0/` root directory, including all 13 files under `inc/font-awesome-7-fallback`. Confirm every required runtime file, the internal version surfaces, and the final SHA-256 checksum. Confirm tests, agent files, development dependencies, build sources, `node_modules`, and `vendor` are absent.
+The two archives must be byte-identical. Before publication, manually confirm the reviewed file count, the single exact versioned root directory, every required runtime file, all version surfaces, and the final SHA-256 checksum. Confirm tests, agent files, development dependencies, build sources, `node_modules`, and any excluded `vendor` directory are absent.
 
 ## Publish
 
-Recent stable BFAL releases use prefix-free, lightweight numeric tags. Release candidates also use prefix-free tags. Stable `2.1.0` promotes the accepted `2.1.0-rc.2` implementation without runtime changes beyond the version constant and resulting stylesheet cache key.
-
-Before publication, confirm `Better_Font_Awesome_Library::VERSION` is `2.1.0` and that WordPress generates `?ver=2.1.0` for both BFAL Font Awesome stylesheet handles. The stable release must retain anonymous CORS mode on the exact `bfa-font-awesome` and `bfa-font-awesome-v4-shim` handles.
-
-Better Font Awesome PR #52 passed manual release-candidate acceptance at exact BFA commit `3351b5e4c02aaf1694bdb7638cc663f398a5c7a4`. The accepted BFA candidate ZIP SHA-256 is `41e37852f70d1ee5d00cf3260a7da45e950f89755ee184e97a1a50a270333e15`.
+Recent BFAL releases use prefix-free, lightweight numeric tags. Release candidates also use prefix-free tags.
 
 After the release-preparation pull request is approved and merged:
 
-1. Confirm the intended merged release commit and that the complete hosted PHP 7.4 through 8.4 and packaging matrix passed on that exact commit.
-2. Create the lightweight `2.1.0` tag locally on the intended merge commit. Do not push it.
+1. Confirm the intended merged release commit and that the complete hosted compatibility and packaging matrix passed on that exact commit.
+2. Create the lightweight release tag locally on the intended merge commit. Do not push it.
 3. Build the production archive twice from that exact unpushed local tag using the commands above.
-4. Confirm byte identity, all archive contents and exclusions, the single exact root directory, every version surface, and the final SHA-256 checksum. Create the `.sha256` file from the verified ZIP.
-5. Confirm the locally tagged commit is exactly the intended merge commit:
-
-   ```console
-   test "$(git rev-parse '2.1.0^{commit}')" = "$(git rev-parse origin/master)"
-   ```
-
-6. Only after every local-tag verification passes, push the tag. Pushing the tag is the publication boundary because Packagist may discover it immediately. Checks performed after this push confirm publication state but cannot prevent publication.
-7. Immediately create the GitHub release and attach both the verified ZIP and its `.sha256` checksum file.
-8. Include the exact SHA-256 checksum directly in the GitHub release notes as well as in the attached checksum file.
-9. Confirm that Packagist discovers stable `2.1.0`, points to the exact tagged merge commit, and that Composer installs the expected distribution contents.
+4. Confirm byte identity, all archive contents and exclusions, the single exact root directory, every version surface, and the final SHA-256 checksum.
+5. Confirm the locally tagged commit is exactly the intended merge commit.
+6. Only after every local-tag verification passes, push the tag. Pushing the tag is the publication boundary because Packagist may discover it immediately.
+7. Create the GitHub release and attach both the verified ZIP and its `.sha256` checksum file.
+8. Include the exact SHA-256 checksum in the GitHub release notes and attached checksum file.
+9. Confirm Packagist discovers the intended version, points to the exact tagged commit, and installs the expected distribution contents.
 
 Do not push the tag if the tagged commit, internal version, changelog, archive contents, archive root directory, byte comparison, or checksum record disagree.
 
 ## Roll back
 
-BFAL 2.0.3 is the rollback release. Restore it in the consuming project and redeploy the updated lockfile:
+Restore the last known-good BFAL version in the consuming project and redeploy the updated lockfile:
 
 ```console
-composer require mickey-kay/better-font-awesome-library:2.0.3 --with-all-dependencies
+composer require mickey-kay/better-font-awesome-library:"<last known-good version>" --with-all-dependencies
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,9 +2,13 @@
 
 BFAL versions are published from repository tags and discovered automatically by Packagist. Do not add a `version` field to `composer.json`.
 
+The active Font Awesome 7 runtime foundation changes the implicit channel default and therefore must not be published on the BFAL 2.x release line. BFAL 2.x remains the Font Awesome 5-compatible line. Before publication, prepare and review a separate BFAL 3.0.0 release change that updates every version surface, compatibility note, archive expectation, and consumer integration requirement. Do not publish the Font Awesome 7 runtime under a 2.x tag.
+
+For development-only archive verification, this foundation adds `inc/class-bfa-release-data-v2-refresher.php` to the 34-file BFAL 2.1.0 inventory, producing 35 regular production files. The future 3.0.0 release-preparation change must replace the historical 2.1.0 archive instructions below with the final reviewed version, root directory, inventory, and checksum expectations.
+
 ## Prepare and verify
 
-When updating the inactive Font Awesome 7 fallback, select one exact official
+When updating the Font Awesome 7 fallback, select one exact official
 npm version and regenerate it with:
 
 ```console

--- a/better-font-awesome-library.php
+++ b/better-font-awesome-library.php
@@ -421,14 +421,15 @@ class Better_Font_Awesome_Library {
 		 * mutate the first caller's selection.
 		 */
 		if ( ! $this->release_channel_resolved ) {
-			$selected = isset( $this->args['release_channel'] ) ? $this->args['release_channel'] : Better_Font_Awesome_Release_Channel::FONT_AWESOME_7;
+			$selected = array_key_exists( 'release_channel', $this->args ) ? $this->args['release_channel'] : null;
 			$selected = apply_filters( 'bfa_font_awesome_release_channel', $selected );
 
 			if ( Better_Font_Awesome_Release_Channel::is_supported( $selected ) ) {
 				$this->release_channel = $selected;
 			} else {
-				$this->release_channel         = Better_Font_Awesome_Release_Channel::FONT_AWESOME_7;
+				$this->release_channel         = '';
 				$this->release_channel_invalid = true;
+				$this->set_error( 'channel', 'bfa_channel_unsupported', 'The selected Font Awesome release channel is not supported.' );
 			}
 
 			$this->release_channel_resolved = true;
@@ -593,6 +594,10 @@ class Better_Font_Awesome_Library {
 	 * @return  array  Release data.
 	 */
 	private function get_font_awesome_release_data() {
+		if ( $this->release_channel_invalid ) {
+			return $this->get_empty_release_data();
+		}
+
 		// 1. Reuse validated instance data for this request.
 		if ( ! empty( $this->release_data ) ) {
 			return $this->release_data;
@@ -758,7 +763,7 @@ class Better_Font_Awesome_Library {
 	 * @since 2.1.0
 	 */
 	public function request_release_data_refresh() {
-		if ( $this->refresh_requested ) {
+		if ( $this->release_channel_invalid || $this->refresh_requested ) {
 			return;
 		}
 
@@ -794,8 +799,7 @@ class Better_Font_Awesome_Library {
 	 */
 	public function refresh_release_data() {
 		if ( $this->release_channel_invalid ) {
-			$this->set_error( 'api', 'bfa_channel_unsupported', 'The selected Font Awesome release channel is not supported.' );
-			return $this->get_error( 'api' );
+			return $this->get_error( 'channel' );
 		}
 
 		if ( Better_Font_Awesome_Release_Channel::FONT_AWESOME_7 === $this->release_channel ) {

--- a/better-font-awesome-library.php
+++ b/better-font-awesome-library.php
@@ -30,6 +30,7 @@ require_once __DIR__ . '/inc/class-bfa-release-data-validator.php';
 require_once __DIR__ . '/inc/class-bfa-release-channel.php';
 require_once __DIR__ . '/inc/class-bfa-release-data-v2-validator.php';
 require_once __DIR__ . '/inc/class-bfa-release-data-v2-adapter.php';
+require_once __DIR__ . '/inc/class-bfa-release-data-v2-refresher.php';
 
 if ( ! class_exists( 'Better_Font_Awesome_Library' ) ) :
 class Better_Font_Awesome_Library {
@@ -79,6 +80,12 @@ class Better_Font_Awesome_Library {
 	 */
 	const FALLBACK_RELEASE_DATA_PATH = 'inc/fallback-release-data.json';
 
+	/** Font Awesome 7 fallback root path. */
+	const FONT_AWESOME_7_FALLBACK_PATH = 'inc/font-awesome-7-fallback/';
+
+	/** Exact-version cdnjs runtime base URL. */
+	const FONT_AWESOME_7_CDN_BASE_URL = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome';
+
 	/**
 	 * Icon prefix.
 	 *
@@ -124,7 +131,29 @@ class Better_Font_Awesome_Library {
 		'load_tinymce_plugin'          => true,
 		'release_data_provider'        => null,
 		'release_data_refresh_callback' => null,
+		'release_channel'              => '7.x',
 	);
+
+	/**
+	 * Immutable release channel selected by the first caller.
+	 *
+	 * @var string
+	 */
+	private $release_channel = '';
+
+	/**
+	 * Whether the immutable release channel has been resolved.
+	 *
+	 * @var bool
+	 */
+	private $release_channel_resolved = false;
+
+	/**
+	 * Whether initialization received an unsupported filtered channel.
+	 *
+	 * @var bool
+	 */
+	private $release_channel_invalid = false;
 
 	/**
 	 * Root URL of the library.
@@ -173,6 +202,20 @@ class Better_Font_Awesome_Library {
 	 * @var array
 	 */
 	private $formatted_icon_array = array();
+
+	/**
+	 * Canonical and alias name map for the selected schema-2 record.
+	 *
+	 * @var array
+	 */
+	private $icon_name_map = array();
+
+	/**
+	 * Validated aliases keyed by schema-2 canonical name.
+	 *
+	 * @var array
+	 */
+	private $icon_alias_map = array();
 
 	/**
 	 * Validated internal release record.
@@ -362,6 +405,27 @@ class Better_Font_Awesome_Library {
 		 */
 		$this->args = apply_filters( 'bfa_init_args', $this->args );
 
+		/*
+		 * Resolve the selected channel exactly once. The established filter remains
+		 * available, but later calls to load() and later singleton callers cannot
+		 * mutate the first caller's selection.
+		 */
+		if ( ! $this->release_channel_resolved ) {
+			$selected = isset( $this->args['release_channel'] ) ? $this->args['release_channel'] : Better_Font_Awesome_Release_Channel::FONT_AWESOME_7;
+			$selected = apply_filters( 'bfa_font_awesome_release_channel', $selected );
+
+			if ( Better_Font_Awesome_Release_Channel::is_supported( $selected ) ) {
+				$this->release_channel = $selected;
+			} else {
+				$this->release_channel         = Better_Font_Awesome_Release_Channel::FONT_AWESOME_7;
+				$this->release_channel_invalid = true;
+			}
+
+			$this->release_channel_resolved = true;
+		}
+
+		$this->args['release_channel'] = $this->release_channel;
+
 		/**
 		 * Filter the wp_remote_get args.
 		 *
@@ -444,6 +508,10 @@ class Better_Font_Awesome_Library {
 	 * @return array Fallback release data.
 	 */
 	private function get_fallback_release_data() {
+		if ( Better_Font_Awesome_Release_Channel::FONT_AWESOME_7 === $this->release_channel ) {
+			return $this->get_font_awesome_7_fallback_release_data();
+		}
+
 		// Set fallback directory path.
 		$bundled_release_data_path  = plugin_dir_path( __FILE__ ) . self::FALLBACK_RELEASE_DATA_PATH;
 		$fallback_release_data_path = $bundled_release_data_path;
@@ -470,6 +538,24 @@ class Better_Font_Awesome_Library {
 		}
 
 		$result        = Better_Font_Awesome_Release_Data_Validator::parse_fallback_json( $fallback_json );
+
+		if ( ! $result['valid'] ) {
+			$this->set_validation_error( 'fallback', $result );
+			return $this->get_empty_release_data();
+		}
+
+		$this->release_record = $result['record'];
+		return $result['record']['release'];
+	}
+
+	/**
+	 * Load and validate the packaged Font Awesome 7 Free baseline.
+	 *
+	 * @return array Valid release data or an empty release shape.
+	 */
+	private function get_font_awesome_7_fallback_release_data() {
+		$path   = plugin_dir_path( __FILE__ ) . self::FONT_AWESOME_7_FALLBACK_PATH . 'metadata.json';
+		$result = Better_Font_Awesome_Release_Data_V2_Validator::parse_record_json( $this->get_local_file_contents( $path ) );
 
 		if ( ! $result['valid'] ) {
 			$this->set_validation_error( 'fallback', $result );
@@ -508,7 +594,7 @@ class Better_Font_Awesome_Library {
 		// 3. Preserve and validate the established transient value shape.
 		$transient_value = get_transient( self::SLUG . '-release-data' );
 		if ( false !== $transient_value ) {
-			$result = Better_Font_Awesome_Release_Data_Validator::validate_release( $transient_value, 'transient' );
+			$result = $this->validate_selected_release_data( $transient_value, 'transient' );
 			if ( $result['valid'] ) {
 				$this->release_record = $result['record'];
 				$this->release_data   = $result['record']['release'];
@@ -543,10 +629,7 @@ class Better_Font_Awesome_Library {
 			return array();
 		}
 
-		$is_record = is_array( $provided ) && ( array_key_exists( 'schema_version', $provided ) || array_key_exists( 'release', $provided ) );
-		$result    = $is_record
-			? Better_Font_Awesome_Release_Data_Validator::validate_record( $provided )
-			: Better_Font_Awesome_Release_Data_Validator::validate_release( $provided, 'provider' );
+		$result = $this->validate_selected_release_data( $provided, 'provider' );
 		if ( ! $result['valid'] ) {
 			$this->set_validation_error( 'provider', $result );
 			return array();
@@ -554,6 +637,27 @@ class Better_Font_Awesome_Library {
 
 		$this->release_record = $result['record'];
 		return $result['record']['release'];
+	}
+
+	/**
+	 * Validate local data against only the immutable selected channel.
+	 *
+	 * @param mixed  $data   Release data or a declared release record.
+	 * @param string $source Local source identifier.
+	 * @return array Validation result.
+	 */
+	private function validate_selected_release_data( $data, $source ) {
+		$is_record = is_array( $data ) && ( array_key_exists( 'schema_version', $data ) || array_key_exists( 'release', $data ) );
+
+		if ( Better_Font_Awesome_Release_Channel::FONT_AWESOME_7 === $this->release_channel ) {
+			return $is_record
+				? Better_Font_Awesome_Release_Data_V2_Validator::validate_record( $data )
+				: Better_Font_Awesome_Release_Data_V2_Validator::validate_release( $data, $source );
+		}
+
+		return $is_record
+			? Better_Font_Awesome_Release_Data_Validator::validate_record( $data )
+			: Better_Font_Awesome_Release_Data_Validator::validate_release( $data, $source );
 	}
 
 	/**
@@ -588,6 +692,48 @@ class Better_Font_Awesome_Library {
 	}
 
 	/**
+	 * Get a validated release asset integrity value.
+	 *
+	 * @param string $expected_path Expected relative asset path.
+	 * @return string Integrity value, or an empty string.
+	 */
+	private function get_release_asset_integrity( $expected_path ) {
+		foreach ( $this->get_release_assets() as $asset ) {
+			if ( isset( $asset['path'], $asset['value'] ) && $expected_path === $asset['path'] ) {
+				return $asset['value'];
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Build a URL for an exact validated stylesheet path.
+	 *
+	 * Packaged fallback assets are used only for the bundled schema-2 record.
+	 * Completely validated newer records use exact-version cdnjs URLs.
+	 *
+	 * @param string $path Relative stylesheet path.
+	 * @return string Asset URL, or an empty string.
+	 */
+	private function get_release_asset_url( $path ) {
+		$version = $this->get_version();
+		if ( '' === $version || ! $this->release_has_asset( $path ) ) {
+			return '';
+		}
+
+		if ( Better_Font_Awesome_Release_Channel::FONT_AWESOME_7 !== $this->release_channel ) {
+			return sprintf( '%s/v%s/%s', self::FONT_AWESOME_CDN_BASE_URL, $version, $path );
+		}
+
+		if ( isset( $this->release_record['source'] ) && 'fallback' === $this->release_record['source'] ) {
+			return $this->root_url . self::FONT_AWESOME_7_FALLBACK_PATH . $path;
+		}
+
+		return sprintf( '%s/%s/%s', self::FONT_AWESOME_7_CDN_BASE_URL, $version, $path );
+	}
+
+	/**
 	 * Request asynchronous release data refresh work from a consumer.
 	 *
 	 * The callback or action handler must schedule work and return promptly. BFAL
@@ -604,7 +750,7 @@ class Better_Font_Awesome_Library {
 		$callback                = isset( $this->args['release_data_refresh_callback'] ) ? $this->args['release_data_refresh_callback'] : null;
 
 		if ( is_callable( $callback ) ) {
-			call_user_func( $callback, Better_Font_Awesome_Release_Data_Validator::RELEASE_CHANNEL, $this );
+			call_user_func( $callback, $this->release_channel, $this );
 			return;
 		}
 
@@ -616,7 +762,7 @@ class Better_Font_Awesome_Library {
 		 * @param string                       $channel Supported release channel.
 		 * @param Better_Font_Awesome_Library $library BFAL instance.
 		 */
-		do_action( 'bfa_release_data_refresh_requested', Better_Font_Awesome_Release_Data_Validator::RELEASE_CHANNEL, $this );
+		do_action( 'bfa_release_data_refresh_requested', $this->release_channel, $this );
 	}
 
 	/**
@@ -631,19 +777,13 @@ class Better_Font_Awesome_Library {
 	 * @return array|WP_Error Valid release data or a sanitized failure.
 	 */
 	public function refresh_release_data() {
-		/**
-		 * Filter the selected Font Awesome release channel.
-		 *
-		 * Only the 5.x Free channel is supported in this release.
-		 *
-		 * @since 2.1.0
-		 *
-		 * @param string $channel Font Awesome release channel.
-		 */
-		$channel = apply_filters( 'bfa_font_awesome_release_channel', Better_Font_Awesome_Release_Data_Validator::RELEASE_CHANNEL );
-		if ( Better_Font_Awesome_Release_Data_Validator::RELEASE_CHANNEL !== $channel ) {
+		if ( $this->release_channel_invalid ) {
 			$this->set_error( 'api', 'bfa_channel_unsupported', 'The selected Font Awesome release channel is not supported.' );
 			return $this->get_error( 'api' );
+		}
+
+		if ( Better_Font_Awesome_Release_Channel::FONT_AWESOME_7 === $this->release_channel ) {
+			return $this->refresh_font_awesome_7_release_data();
 		}
 
 		$query_args            = $this->wp_remote_get_args;
@@ -720,6 +860,39 @@ class Better_Font_Awesome_Library {
 	}
 
 	/**
+	 * Refresh the selected Font Awesome 7 channel without BFAL persistence.
+	 *
+	 * The consumer owns durable last-known-good storage. A successful attempt
+	 * returns a complete schema-2 record and updates only this request's instance.
+	 *
+	 * @return array|WP_Error Complete schema-2 record or sanitized failure.
+	 */
+	private function refresh_font_awesome_7_release_data() {
+		$this->get_font_awesome_release_data();
+		$result = Better_Font_Awesome_Release_Data_V2_Refresher::refresh( $this->wp_remote_get_args, $this->release_record );
+
+		if ( is_wp_error( $result ) ) {
+			$this->set_error( 'api', $result->get_error_code(), $result->get_error_message() );
+			return $this->get_error( 'api' );
+		}
+
+		$validated = Better_Font_Awesome_Release_Data_V2_Validator::validate_record( $result );
+		if ( ! $validated['valid'] ) {
+			$this->set_validation_error( 'api', $validated );
+			return $this->get_error( 'api' );
+		}
+
+		$this->release_record       = $validated['record'];
+		$this->release_data         = $validated['record']['release'];
+		$this->formatted_icon_array = array();
+		$this->icon_name_map        = array();
+		$this->icon_alias_map       = array();
+		unset( $this->errors['api'] );
+
+		return $validated['record'];
+	}
+
+	/**
 	 * Get array of icons for the current version.
 	 *
 	 * @since   1.0.0
@@ -747,12 +920,18 @@ class Better_Font_Awesome_Library {
 			}
 
 			foreach ( $icon_styles as $icon_style ) {
+				$search_terms = $icon_metadata['id'];
+				if ( Better_Font_Awesome_Release_Channel::FONT_AWESOME_7 === $this->release_channel ) {
+					$aliases      = $this->get_font_awesome_7_icon_aliases( $icon_metadata['id'] );
+					$search_terms = implode( ' ', array_merge( array( $icon_metadata['id'] ), $aliases ) );
+				}
+
 				$icons[] = [
 					'title'       => "{$icon_metadata['label']} ({$icon_style})",
 					'slug'        => $icon_metadata['id'],
 					'style'       => $icon_style,
 					'base_class'  => $this->get_icon_base_class( $icon_metadata['id'], $icon_style ),
-					'searchTerms' => $icon_metadata['id'],
+					'searchTerms' => $search_terms,
 				];
 			}
 		}
@@ -779,6 +958,17 @@ class Better_Font_Awesome_Library {
 		$this->formatted_icon_array = $icons;
 
 		return $icons;
+	}
+
+	/**
+	 * Get validated aliases for one schema-2 canonical icon.
+	 *
+	 * @param string $canonical_id Canonical icon ID.
+	 * @return array Name aliases.
+	 */
+	private function get_font_awesome_7_icon_aliases( $canonical_id ) {
+		$this->initialize_font_awesome_7_icon_name_maps();
+		return isset( $this->icon_alias_map[ $canonical_id ] ) ? $this->icon_alias_map[ $canonical_id ] : array();
 	}
 
 	/**
@@ -839,7 +1029,46 @@ class Better_Font_Awesome_Library {
 
 		}
 
+		if ( Better_Font_Awesome_Release_Channel::FONT_AWESOME_7 === $this->release_channel ) {
+			$resolved = $this->resolve_font_awesome_7_icon_name( $name );
+			if ( null !== $resolved ) {
+				$name = $resolved;
+			}
+		}
+
 		return $name;
+	}
+
+	/**
+	 * Resolve a schema-2 canonical icon name or validated alias.
+	 *
+	 * @param string $name Canonical name or alias.
+	 * @return string|null Canonical name, or null when unknown.
+	 */
+	private function resolve_font_awesome_7_icon_name( $name ) {
+		$this->initialize_font_awesome_7_icon_name_maps();
+
+		return isset( $this->icon_name_map[ $name ] ) ? $this->icon_name_map[ $name ] : null;
+	}
+
+	/**
+	 * Build canonical and alias lookup maps once per validated schema-2 record.
+	 */
+	private function initialize_font_awesome_7_icon_name_maps() {
+		if ( ! empty( $this->icon_name_map ) ) {
+			return;
+		}
+
+		foreach ( $this->get_font_awesome_release_data()['icons'] as $icon ) {
+			$this->icon_name_map[ $icon['id'] ]  = $icon['id'];
+			$this->icon_alias_map[ $icon['id'] ] = $icon['aliases']['names'];
+		}
+
+		foreach ( $this->get_font_awesome_release_data()['icons'] as $icon ) {
+			foreach ( $icon['aliases']['names'] as $alias ) {
+				$this->icon_name_map[ $alias ] = $icon['id'];
+			}
+		}
 	}
 
 	public function sanitize_shortcode_class_att( $class ) {
@@ -986,8 +1215,10 @@ class Better_Font_Awesome_Library {
 	 */
 	private function add_font_awesome_crossorigin_attribute( $html, $handle ) {
 		$font_awesome_handles = array(
-			self::SLUG . '-font-awesome'         => self::SLUG . '-font-awesome-css',
-			self::SLUG . '-font-awesome-v4-shim' => self::SLUG . '-font-awesome-v4-shim-css',
+			self::SLUG . '-font-awesome'              => array( self::SLUG . '-font-awesome-css', 'css/all.min.css' ),
+			self::SLUG . '-font-awesome-v5-compat'    => array( self::SLUG . '-font-awesome-v5-compat-css', 'css/v5-font-face.min.css' ),
+			self::SLUG . '-font-awesome-v4-font-face' => array( self::SLUG . '-font-awesome-v4-font-face-css', 'css/v4-font-face.min.css' ),
+			self::SLUG . '-font-awesome-v4-shim'      => array( self::SLUG . '-font-awesome-v4-shim-css', 'css/v4-shims.min.css' ),
 		);
 
 		if ( ! isset( $font_awesome_handles[ $handle ] ) || ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
@@ -995,7 +1226,7 @@ class Better_Font_Awesome_Library {
 		}
 
 		$processor   = new WP_HTML_Tag_Processor( $html );
-		$expected_id = $font_awesome_handles[ $handle ];
+		$expected_id = $font_awesome_handles[ $handle ][0];
 		while ( $processor->next_tag( array( 'tag_name' => 'LINK' ) ) ) {
 			if ( $expected_id !== $processor->get_attribute( 'id' ) ) {
 				continue;
@@ -1003,6 +1234,13 @@ class Better_Font_Awesome_Library {
 
 			if ( ! $processor->set_attribute( 'crossorigin', 'anonymous' ) ) {
 				return $html;
+			}
+
+			if ( Better_Font_Awesome_Release_Channel::FONT_AWESOME_7 === $this->release_channel ) {
+				$integrity = $this->get_release_asset_integrity( $font_awesome_handles[ $handle ][1] );
+				if ( '' === $integrity || ! $processor->set_attribute( 'integrity', $integrity ) ) {
+					return $html;
+				}
 			}
 
 			return $processor->get_updated_html();
@@ -1015,6 +1253,11 @@ class Better_Font_Awesome_Library {
 	 * Register and enqueue Font Awesome CSS.
 	 */
 	public function register_font_awesome_css() {
+		if ( Better_Font_Awesome_Release_Channel::FONT_AWESOME_7 === $this->release_channel ) {
+			$this->register_font_awesome_7_css();
+			return;
+		}
+
 		$stylesheet_url = $this->get_stylesheet_url();
 		if ( '' === $stylesheet_url ) {
 			return;
@@ -1050,11 +1293,45 @@ class Better_Font_Awesome_Library {
 	}
 
 	/**
+	 * Register the minimal Font Awesome 7 runtime and compatibility styles.
+	 */
+	private function register_font_awesome_7_css() {
+		$styles = array(
+			self::SLUG . '-font-awesome'           => array( $this->get_stylesheet_url(), array() ),
+			self::SLUG . '-font-awesome-v5-compat' => array( $this->get_release_asset_url( 'css/v5-font-face.min.css' ), array( self::SLUG . '-font-awesome' ) ),
+		);
+
+		if ( $this->args['include_v4_shim'] ) {
+			$styles[ self::SLUG . '-font-awesome-v4-font-face' ] = array(
+				$this->get_release_asset_url( 'css/v4-font-face.min.css' ),
+				array( self::SLUG . '-font-awesome' ),
+			);
+			$styles[ self::SLUG . '-font-awesome-v4-shim' ] = array(
+				$this->get_stylesheet_url_v4_shim(),
+				array( self::SLUG . '-font-awesome', self::SLUG . '-font-awesome-v4-font-face' ),
+			);
+		}
+
+		foreach ( $styles as $handle => $style ) {
+			if ( '' === $style[0] ) {
+				return;
+			}
+
+			wp_register_style( $handle, $style[0], $style[1], self::VERSION );
+			wp_enqueue_style( $handle );
+		}
+	}
+
+	/**
 	 * Enqueue inline v4 shim CSS to alias legacy @font-face declarations.
 	 *
 	 * @since  2.0.1
 	 */
 	public function register_v4_shim_inline_css () {
+		if ( Better_Font_Awesome_Release_Channel::FONT_AWESOME_7 === $this->release_channel ) {
+			return;
+		}
+
 		$v4_shim_font_face = "
 			@font-face {
 				font-family: 'FontAwesome';
@@ -1103,6 +1380,20 @@ class Better_Font_Awesome_Library {
 		$stylesheet_url = $this->get_stylesheet_url();
 		if ( '' !== $stylesheet_url ) {
 			add_editor_style( $stylesheet_url );
+		}
+
+		if ( Better_Font_Awesome_Release_Channel::FONT_AWESOME_7 === $this->release_channel ) {
+			$v5_compat_url = $this->get_release_asset_url( 'css/v5-font-face.min.css' );
+			if ( '' !== $v5_compat_url ) {
+				add_editor_style( $v5_compat_url );
+			}
+
+			if ( $this->args['include_v4_shim'] ) {
+				$v4_font_face_url = $this->get_release_asset_url( 'css/v4-font-face.min.css' );
+				if ( '' !== $v4_font_face_url ) {
+					add_editor_style( $v4_font_face_url );
+				}
+			}
 		}
 
 		// Conditionally include the Font Awesome v4 CSS shim.
@@ -1338,17 +1629,8 @@ class Better_Font_Awesome_Library {
 	 * @return  string  Stylesheet URL.
 	 */
 	public function get_stylesheet_url() {
-		$version = $this->get_version();
-		if ( '' === $version || ! $this->release_has_asset( 'css/all.css' ) ) {
-			return '';
-		}
-
-		return sprintf(
-			'%s/v%s/%s',
-			self::FONT_AWESOME_CDN_BASE_URL,
-			$version,
-			'css/all.css'
-		);
+		$path = Better_Font_Awesome_Release_Channel::FONT_AWESOME_7 === $this->release_channel ? 'css/all.min.css' : 'css/all.css';
+		return $this->get_release_asset_url( $path );
 	}
 
 	/**
@@ -1359,17 +1641,8 @@ class Better_Font_Awesome_Library {
 	 * @return  string  Stylesheet URL.
 	 */
 	public function get_stylesheet_url_v4_shim() {
-		$version = $this->get_version();
-		if ( '' === $version || ! $this->release_has_asset( 'css/v4-shims.css' ) ) {
-			return '';
-		}
-
-		return sprintf(
-			'%s/v%s/%s',
-			self::FONT_AWESOME_CDN_BASE_URL,
-			$version,
-			'css/v4-shims.css'
-		);
+		$path = Better_Font_Awesome_Release_Channel::FONT_AWESOME_7 === $this->release_channel ? 'css/v4-shims.min.css' : 'css/v4-shims.css';
+		return $this->get_release_asset_url( $path );
 	}
 
 	/**
@@ -1395,7 +1668,27 @@ class Better_Font_Awesome_Library {
 	 */
 	public function get_release_icons() {
 		$release_data = $this->get_font_awesome_release_data();
-		return isset( $release_data['icons'] ) && is_array( $release_data['icons'] ) ? $release_data['icons'] : array();
+		$icons        = isset( $release_data['icons'] ) && is_array( $release_data['icons'] ) ? $release_data['icons'] : array();
+		if ( Better_Font_Awesome_Release_Channel::FONT_AWESOME_7 !== $this->release_channel ) {
+			return $icons;
+		}
+
+		$adapted = array();
+		foreach ( $icons as $icon ) {
+			$styles = array();
+			foreach ( $icon['familyStylesByLicense']['free'] as $membership ) {
+				$styles[] = $membership['style'];
+			}
+
+			$adapted[] = array(
+				'id'         => $icon['id'],
+				'label'      => $icon['label'],
+				'membership' => array( 'free' => $styles ),
+				'styles'     => $styles,
+			);
+		}
+
+		return $adapted;
 	}
 
 	/**
@@ -1430,7 +1723,7 @@ class Better_Font_Awesome_Library {
 	 * @return string Release channel.
 	 */
 	public function get_release_channel() {
-		return Better_Font_Awesome_Release_Data_Validator::RELEASE_CHANNEL;
+		return $this->release_channel;
 	}
 
 	/**

--- a/better-font-awesome-library.php
+++ b/better-font-awesome-library.php
@@ -225,6 +225,16 @@ class Better_Font_Awesome_Library {
 	private $release_record = array();
 
 	/**
+	 * Whether BFAL loaded the active record from its own packaged FA7 fallback.
+	 *
+	 * Record source is provenance supplied by the record and is not trusted for
+	 * local asset routing.
+	 *
+	 * @var bool
+	 */
+	private $using_bundled_font_awesome_7_fallback = false;
+
+	/**
 	 * Whether a refresh request has been emitted during this request.
 	 *
 	 * @var bool
@@ -512,6 +522,8 @@ class Better_Font_Awesome_Library {
 			return $this->get_font_awesome_7_fallback_release_data();
 		}
 
+		$this->using_bundled_font_awesome_7_fallback = false;
+
 		// Set fallback directory path.
 		$bundled_release_data_path  = plugin_dir_path( __FILE__ ) . self::FALLBACK_RELEASE_DATA_PATH;
 		$fallback_release_data_path = $bundled_release_data_path;
@@ -554,6 +566,7 @@ class Better_Font_Awesome_Library {
 	 * @return array Valid release data or an empty release shape.
 	 */
 	private function get_font_awesome_7_fallback_release_data() {
+		$this->using_bundled_font_awesome_7_fallback = false;
 		$path   = plugin_dir_path( __FILE__ ) . self::FONT_AWESOME_7_FALLBACK_PATH . 'metadata.json';
 		$result = Better_Font_Awesome_Release_Data_V2_Validator::parse_record_json( $this->get_local_file_contents( $path ) );
 
@@ -563,6 +576,7 @@ class Better_Font_Awesome_Library {
 		}
 
 		$this->release_record = $result['record'];
+		$this->using_bundled_font_awesome_7_fallback = true;
 		return $result['record']['release'];
 	}
 
@@ -596,8 +610,9 @@ class Better_Font_Awesome_Library {
 		if ( false !== $transient_value ) {
 			$result = $this->validate_selected_release_data( $transient_value, 'transient' );
 			if ( $result['valid'] ) {
-				$this->release_record = $result['record'];
-				$this->release_data   = $result['record']['release'];
+				$this->using_bundled_font_awesome_7_fallback = false;
+				$this->release_record                           = $result['record'];
+				$this->release_data                             = $result['record']['release'];
 				return $this->release_data;
 			}
 
@@ -635,7 +650,8 @@ class Better_Font_Awesome_Library {
 			return array();
 		}
 
-		$this->release_record = $result['record'];
+		$this->using_bundled_font_awesome_7_fallback = false;
+		$this->release_record                           = $result['record'];
 		return $result['record']['release'];
 	}
 
@@ -726,7 +742,7 @@ class Better_Font_Awesome_Library {
 			return sprintf( '%s/v%s/%s', self::FONT_AWESOME_CDN_BASE_URL, $version, $path );
 		}
 
-		if ( isset( $this->release_record['source'] ) && 'fallback' === $this->release_record['source'] ) {
+		if ( $this->using_bundled_font_awesome_7_fallback ) {
 			return $this->root_url . self::FONT_AWESOME_7_FALLBACK_PATH . $path;
 		}
 
@@ -851,9 +867,10 @@ class Better_Font_Awesome_Library {
 			return $this->get_error( 'api' );
 		}
 
-		$this->release_record       = $result['record'];
-		$this->release_data         = $release_data;
-		$this->formatted_icon_array = array();
+		$this->using_bundled_font_awesome_7_fallback = false;
+		$this->release_record                           = $result['record'];
+		$this->release_data                             = $release_data;
+		$this->formatted_icon_array                     = array();
 		unset( $this->errors['api'] );
 
 		return $release_data;
@@ -882,11 +899,12 @@ class Better_Font_Awesome_Library {
 			return $this->get_error( 'api' );
 		}
 
-		$this->release_record       = $validated['record'];
-		$this->release_data         = $validated['record']['release'];
-		$this->formatted_icon_array = array();
-		$this->icon_name_map        = array();
-		$this->icon_alias_map       = array();
+		$this->using_bundled_font_awesome_7_fallback = false;
+		$this->release_record                           = $validated['record'];
+		$this->release_data                             = $validated['record']['release'];
+		$this->formatted_icon_array                     = array();
+		$this->icon_name_map                            = array();
+		$this->icon_alias_map                           = array();
 		unset( $this->errors['api'] );
 
 		return $validated['record'];

--- a/inc/class-bfa-release-channel.php
+++ b/inc/class-bfa-release-channel.php
@@ -9,8 +9,8 @@ if ( ! class_exists( 'Better_Font_Awesome_Release_Channel' ) ) :
 	/**
 	 * Major-aware release channel value helpers.
 	 *
-	 * This class is internal foundation for release validation. It does not
-	 * select or activate a production release channel.
+	 * This class defines the only release channels that the immutable runtime
+	 * selection may activate.
 	 *
 	 * @internal
 	 */
@@ -19,7 +19,7 @@ if ( ! class_exists( 'Better_Font_Awesome_Release_Channel' ) ) :
 		/** Existing production channel. */
 		const FONT_AWESOME_5 = '5.x';
 
-		/** Inactive Font Awesome 7 foundation channel. */
+		/** Font Awesome 7 channel. */
 		const FONT_AWESOME_7 = '7.x';
 
 		/**

--- a/inc/class-bfa-release-data-v2-adapter.php
+++ b/inc/class-bfa-release-data-v2-adapter.php
@@ -7,7 +7,7 @@
 
 if ( ! class_exists( 'Better_Font_Awesome_Release_Data_V2_Adapter' ) ) :
 	/**
-	 * Adapt validated family/style metadata for future internal consumers.
+	 * Adapt validated family/style metadata for internal consumers.
 	 *
 	 * @internal
 	 */

--- a/inc/class-bfa-release-data-v2-refresher.php
+++ b/inc/class-bfa-release-data-v2-refresher.php
@@ -1,0 +1,406 @@
+<?php
+/**
+ * Bounded Font Awesome 7 Free release refresh worker.
+ *
+ * @package Better_Font_Awesome_Library
+ */
+
+if ( ! class_exists( 'Better_Font_Awesome_Release_Data_V2_Refresher' ) ) :
+	/**
+	 * Discover and completely validate one Font Awesome 7 candidate.
+	 *
+	 * @internal
+	 */
+	class Better_Font_Awesome_Release_Data_V2_Refresher {
+
+		/** Hard request budget for one new-candidate attempt. */
+		const MAX_REQUESTS = 18;
+
+		/** Hard aggregate response-body budget. */
+		const MAX_TOTAL_BYTES = 4194304;
+
+		/** Hard wall-clock budget in seconds. */
+		const MAX_TOTAL_SECONDS = 30;
+
+		/** Maximum timeout for one request. */
+		const MAX_REQUEST_SECONDS = 5;
+
+		/** Maximum Font Awesome metadata response size. */
+		const MAX_METADATA_BYTES = 2097152;
+
+		/** Maximum exact npm version response size. */
+		const MAX_NPM_BYTES = 262144;
+
+		/** Expected upstream package identity. */
+		const NPM_PACKAGE = '@fortawesome/fontawesome-free';
+
+		/** Expected upstream package license identity. */
+		const NPM_LICENSE = '(CC-BY-4.0 AND OFL-1.1 AND MIT)';
+
+		/** @var array Base WordPress HTTP arguments. */
+		private $request_args;
+
+		/** @var int Number of requests made. */
+		private $request_count = 0;
+
+		/** @var int Number of response bytes consumed. */
+		private $response_bytes = 0;
+
+		/** @var float Attempt start time. */
+		private $started_at;
+
+		/**
+		 * Perform one bounded refresh attempt.
+		 *
+		 * @param array $request_args  Base WordPress HTTP arguments.
+		 * @param array $current_record Completely validated current schema-2 record.
+		 * @return array|WP_Error Complete validated schema-2 record or sanitized error.
+		 */
+		public static function refresh( $request_args, $current_record ) {
+			$worker = new self( $request_args );
+			return $worker->run( $current_record );
+		}
+
+		/**
+		 * Initialize one attempt.
+		 *
+		 * @param array $request_args Base WordPress HTTP arguments.
+		 */
+		private function __construct( $request_args ) {
+			$this->request_args = is_array( $request_args ) ? $request_args : array();
+			$this->started_at   = microtime( true );
+		}
+
+		/**
+		 * Run discovery and new-candidate validation.
+		 *
+		 * @param array $current_record Current schema-2 record.
+		 * @return array|WP_Error Valid record or error.
+		 */
+		private function run( $current_record ) {
+			$current = Better_Font_Awesome_Release_Data_V2_Validator::validate_record( $current_record );
+			if ( ! $current['valid'] ) {
+				return $this->failure( 'bfa_v2_current_invalid', 'The current Font Awesome 7 release record was invalid.' );
+			}
+
+			$candidate = $this->discover_candidate();
+			if ( is_wp_error( $candidate ) ) {
+				return $candidate;
+			}
+
+			$current_version   = $current['record']['release']['version'];
+			$candidate_version = $candidate['version'];
+			$comparison        = version_compare( $candidate_version, $current_version );
+			if ( 0 === $comparison ) {
+				return $current['record'];
+			}
+
+			if ( $comparison < 0 ) {
+				return $this->failure( 'bfa_v2_version_regression', 'Font Awesome metadata discovery returned an older 7.x release.' );
+			}
+
+			$npm = $this->confirm_npm_version( $candidate_version );
+			if ( is_wp_error( $npm ) ) {
+				return $npm;
+			}
+
+			$assets = $this->validate_cross_provider_assets( $candidate_version );
+			if ( is_wp_error( $assets ) ) {
+				return $assets;
+			}
+
+			$candidate['srisByLicense'] = array(
+				'free' => $assets['sris'],
+			);
+			$result = Better_Font_Awesome_Release_Data_V2_Validator::validate_release( $candidate, 'api' );
+			if ( ! $result['valid'] ) {
+				return $this->validation_failure( $result );
+			}
+
+			return $result['record'];
+		}
+
+		/**
+		 * Discover the latest 7.x Free icon metadata from Font Awesome.
+		 *
+		 * @return array|WP_Error Candidate release without asset SRI values, or error.
+		 */
+		private function discover_candidate() {
+			$args            = $this->request_args;
+			$args['headers'] = array( 'Content-Type' => 'application/json' );
+			$args['body']    = wp_json_encode(
+				array(
+					'query' => 'query { release(version: "7.x") { version icons(license: "free") { id label aliases { names } familyStylesByLicense { free { family style } } } } }',
+				)
+			);
+
+			$body = $this->request( 'POST', Better_Font_Awesome_Library::FONT_AWESOME_API_BASE_URL, $args, self::MAX_METADATA_BYTES, 'metadata' );
+			if ( is_wp_error( $body ) ) {
+				return $body;
+			}
+
+			$decoded = json_decode( $body, true );
+			if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $decoded ) ) {
+				return $this->failure( 'bfa_v2_invalid_json', 'The Font Awesome 7 metadata response was not valid JSON.' );
+			}
+
+			if ( ! empty( $decoded['errors'] ) ) {
+				return $this->failure( 'bfa_v2_graphql_error', 'The Font Awesome 7 metadata service rejected the release query.' );
+			}
+
+			if ( ! isset( $decoded['data']['release'] ) || ! is_array( $decoded['data']['release'] ) ) {
+				return $this->failure( 'bfa_v2_schema_invalid', 'Font Awesome 7 metadata was missing the release object.' );
+			}
+
+			$release = $decoded['data']['release'];
+			if ( ! isset( $release['icons'] ) || ! is_array( $release['icons'] ) ) {
+				return $this->failure( 'bfa_v2_icons_empty', 'Font Awesome 7 metadata did not contain Free icons.' );
+			}
+
+			foreach ( $release['icons'] as &$icon ) {
+				if ( is_array( $icon ) && ! isset( $icon['aliases'] ) ) {
+					$icon['aliases'] = array( 'names' => array() );
+				}
+			}
+			unset( $icon );
+
+			$placeholder = $release;
+			$placeholder['srisByLicense'] = array(
+				'free' => $this->placeholder_sris(),
+			);
+			$validated = Better_Font_Awesome_Release_Data_V2_Validator::validate_release( $placeholder, 'api' );
+			if ( ! $validated['valid'] ) {
+				return $this->validation_failure( $validated );
+			}
+
+			return array(
+				'version' => $release['version'],
+				'icons'   => $release['icons'],
+			);
+		}
+
+		/**
+		 * Confirm that the exact official npm package version is published.
+		 *
+		 * @param string $version Candidate version.
+		 * @return true|WP_Error True or error.
+		 */
+		private function confirm_npm_version( $version ) {
+			$url  = 'https://registry.npmjs.org/%40fortawesome%2Ffontawesome-free/' . rawurlencode( $version );
+			$body = $this->request( 'GET', $url, $this->request_args, self::MAX_NPM_BYTES, 'publication' );
+			if ( is_wp_error( $body ) ) {
+				return $body;
+			}
+
+			$metadata = json_decode( $body, true );
+			if (
+				JSON_ERROR_NONE !== json_last_error() ||
+				! is_array( $metadata ) ||
+				! isset( $metadata['name'], $metadata['version'], $metadata['license'] ) ||
+				self::NPM_PACKAGE !== $metadata['name'] ||
+				$version !== $metadata['version'] ||
+				self::NPM_LICENSE !== $metadata['license']
+			) {
+				return $this->failure( 'bfa_v2_publication_invalid', 'The exact Font Awesome Free npm package identity was invalid.' );
+			}
+
+			return true;
+		}
+
+		/**
+		 * Validate exact cdnjs assets against the corresponding jsDelivr npm files.
+		 *
+		 * @param string $version Candidate version.
+		 * @return array|WP_Error SRI rows and validated asset bodies, or error.
+		 */
+		private function validate_cross_provider_assets( $version ) {
+			$limits = array(
+				'css/all.min.css'                    => 524288,
+				'css/v4-font-face.min.css'           => 131072,
+				'css/v4-shims.min.css'               => 262144,
+				'css/v5-font-face.min.css'           => 131072,
+				'webfonts/fa-brands-400.woff2'       => 524288,
+				'webfonts/fa-regular-400.woff2'      => 262144,
+				'webfonts/fa-solid-900.woff2'        => 524288,
+				'webfonts/fa-v4compatibility.woff2'  => 131072,
+			);
+			$css_bodies = array();
+			$sris       = array();
+
+			foreach ( $limits as $path => $limit ) {
+				$cdnjs_url = sprintf(
+					'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/%s/%s',
+					rawurlencode( $version ),
+					$path
+				);
+				$jsdelivr_url = sprintf(
+					'https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@%s/%s',
+					rawurlencode( $version ),
+					$path
+				);
+
+				$cdnjs = $this->request( 'GET', $cdnjs_url, $this->request_args, $limit, 'publication' );
+				if ( is_wp_error( $cdnjs ) ) {
+					return $cdnjs;
+				}
+
+				$jsdelivr = $this->request( 'GET', $jsdelivr_url, $this->request_args, $limit, 'publication' );
+				if ( is_wp_error( $jsdelivr ) ) {
+					return $jsdelivr;
+				}
+
+				if ( '' === $cdnjs || ! hash_equals( hash( 'sha512', $cdnjs ), hash( 'sha512', $jsdelivr ) ) ) {
+					return $this->failure( 'bfa_v2_provider_disagreement', 'The Font Awesome asset providers disagreed on exact candidate bytes.' );
+				}
+
+				if ( 0 === strpos( $path, 'css/' ) ) {
+					$css_bodies[ $path ] = $cdnjs;
+					$sris[] = array(
+						'path'  => $path,
+						'value' => 'sha512-' . base64_encode( hash( 'sha512', $cdnjs, true ) ),
+					);
+				}
+			}
+
+			$css_result = $this->validate_css_font_references( $css_bodies );
+			if ( is_wp_error( $css_result ) ) {
+				return $css_result;
+			}
+
+			return array( 'sris' => $sris );
+		}
+
+		/**
+		 * Require CSS to reference only the exact validated WOFF2 inventory.
+		 *
+		 * @param array $css_bodies CSS keyed by relative path.
+		 * @return true|WP_Error True or error.
+		 */
+		private function validate_css_font_references( $css_bodies ) {
+			$required = array(
+				'fa-brands-400.woff2',
+				'fa-regular-400.woff2',
+				'fa-solid-900.woff2',
+				'fa-v4compatibility.woff2',
+			);
+			$found = array();
+
+			foreach ( $css_bodies as $css ) {
+				preg_match_all( '#url\(([^)]+)\)#', $css, $matches );
+				foreach ( $matches[1] as $url ) {
+					$url = trim( $url, " \t\n\r\0\x0B\"'" );
+					if ( ! preg_match( '#^\.\./webfonts/(fa-[a-z0-9-]+\.woff2)\z#', $url, $path_match ) || ! in_array( $path_match[1], $required, true ) ) {
+						return $this->failure( 'bfa_v2_font_reference_invalid', 'Font Awesome candidate CSS referenced an invalid font asset.' );
+					}
+					$found[ $path_match[1] ] = true;
+				}
+			}
+
+			if ( $required !== array_values( array_intersect( $required, array_keys( $found ) ) ) ) {
+				return $this->failure( 'bfa_v2_font_missing', 'Font Awesome candidate CSS did not reference every required font asset.' );
+			}
+
+			return true;
+		}
+
+		/**
+		 * Execute one budgeted WordPress HTTP request.
+		 *
+		 * @param string $method       GET or POST.
+		 * @param string $url          Exact allowlisted URL.
+		 * @param array  $args         Request arguments.
+		 * @param int    $response_max Per-response byte limit.
+		 * @param string $failure_type Failure category.
+		 * @return string|WP_Error Response body or error.
+		 */
+		private function request( $method, $url, $args, $response_max, $failure_type ) {
+			$elapsed   = microtime( true ) - $this->started_at;
+			$remaining = self::MAX_TOTAL_SECONDS - $elapsed;
+			if ( $this->request_count >= self::MAX_REQUESTS || $remaining <= 0 ) {
+				return $this->failure( 'bfa_v2_budget_exceeded', 'The Font Awesome 7 refresh exceeded its request or time budget.' );
+			}
+
+			$remaining_bytes = self::MAX_TOTAL_BYTES - $this->response_bytes;
+			if ( $remaining_bytes <= 0 ) {
+				return $this->failure( 'bfa_v2_budget_exceeded', 'The Font Awesome 7 refresh exceeded its response byte budget.' );
+			}
+
+			$configured_timeout = isset( $args['timeout'] ) ? (float) $args['timeout'] : self::MAX_REQUEST_SECONDS;
+			$configured_limit   = isset( $args['limit_response_size'] ) ? (int) $args['limit_response_size'] : $response_max;
+
+			$args['sslverify']           = true;
+			$args['redirection']         = 0;
+			$args['reject_unsafe_urls']  = true;
+			$args['blocking']            = true;
+			$args['timeout']             = max( 0.1, min( $configured_timeout, self::MAX_REQUEST_SECONDS, $remaining ) );
+			$args['limit_response_size'] = max( 1, min( $configured_limit, (int) $response_max, $remaining_bytes ) );
+			++$this->request_count;
+
+			$response = 'POST' === $method ? wp_remote_post( $url, $args ) : wp_remote_get( $url, $args );
+			if ( is_wp_error( $response ) ) {
+				return $this->failure( 'bfa_v2_transport_error', 'A required Font Awesome 7 provider could not be reached.' );
+			}
+
+			$status = (int) wp_remote_retrieve_response_code( $response );
+			if ( $status < 200 || $status >= 300 ) {
+				$code = 'publication' === $failure_type ? 'bfa_v2_publication_lag' : 'bfa_v2_http_error';
+				return $this->failure( $code, 'A required Font Awesome 7 provider did not publish the candidate successfully.' );
+			}
+
+			$body        = wp_remote_retrieve_body( $response );
+			$body_length = strlen( $body );
+			if ( $body_length >= $args['limit_response_size'] ) {
+				return $this->failure( 'bfa_v2_response_too_large', 'A Font Awesome 7 provider response reached its strict size limit.' );
+			}
+
+			$this->response_bytes += $body_length;
+			if ( $this->response_bytes > self::MAX_TOTAL_BYTES || ( microtime( true ) - $this->started_at ) > self::MAX_TOTAL_SECONDS ) {
+				return $this->failure( 'bfa_v2_budget_exceeded', 'The Font Awesome 7 refresh exceeded its overall resource budget.' );
+			}
+
+			return $body;
+		}
+
+		/**
+		 * Build syntactically valid temporary SRI rows for early metadata validation.
+		 *
+		 * @return array Placeholder SRI rows.
+		 */
+		private function placeholder_sris() {
+			$integrity = 'sha512-' . base64_encode( str_repeat( "\0", 64 ) );
+			$rows      = array();
+			foreach ( array( 'css/all.min.css', 'css/v4-font-face.min.css', 'css/v4-shims.min.css', 'css/v5-font-face.min.css' ) as $path ) {
+				$rows[] = array(
+					'path'  => $path,
+					'value' => $integrity,
+				);
+			}
+			return $rows;
+		}
+
+		/**
+		 * Convert a validator failure to a sanitized WordPress error.
+		 *
+		 * @param array $result Validator result.
+		 * @return WP_Error Error.
+		 */
+		private function validation_failure( $result ) {
+			$error = isset( $result['error'] ) && is_array( $result['error'] ) ? $result['error'] : array();
+			return $this->failure(
+				isset( $error['code'] ) ? $error['code'] : 'bfa_v2_validation_error',
+				isset( $error['message'] ) ? $error['message'] : 'Font Awesome 7 candidate validation failed.'
+			);
+		}
+
+		/**
+		 * Create a sanitized worker failure.
+		 *
+		 * @param string $code    Stable error code.
+		 * @param string $message Safe diagnostic.
+		 * @return WP_Error Error.
+		 */
+		private function failure( $code, $message ) {
+			return new WP_Error( $code, $message );
+		}
+	}
+endif;

--- a/inc/class-bfa-release-data-v2-validator.php
+++ b/inc/class-bfa-release-data-v2-validator.php
@@ -7,7 +7,7 @@
 
 if ( ! class_exists( 'Better_Font_Awesome_Release_Data_V2_Validator' ) ) :
 	/**
-	 * Validate the internal family-aware schema without activating it.
+	 * Validate the internal family-aware schema used by the 7.x channel.
 	 *
 	 * @internal
 	 */
@@ -16,7 +16,7 @@ if ( ! class_exists( 'Better_Font_Awesome_Release_Data_V2_Validator' ) ) :
 		/** Version of the family-aware release record shape. */
 		const SCHEMA_VERSION = 2;
 
-		/** Inactive foundation channel represented by this schema. */
+		/** Release channel represented by this schema. */
 		const RELEASE_CHANNEL = '7.x';
 
 		/** Supported Font Awesome edition. */
@@ -386,7 +386,7 @@ if ( ! class_exists( 'Better_Font_Awesome_Release_Data_V2_Validator' ) ) :
 		 * @return bool Whether the source is valid.
 		 */
 		private static function is_valid_source( $source ) {
-			return is_string( $source ) && in_array( $source, array( 'fallback', 'fixture', 'provider', 'unknown' ), true );
+			return is_string( $source ) && in_array( $source, array( 'api', 'fallback', 'fixture', 'provider', 'transient', 'unknown' ), true );
 		}
 
 		/**

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,6 +7,7 @@
     <file>inc/class-bfa-release-channel.php</file>
     <file>inc/class-bfa-release-data-v2-validator.php</file>
     <file>inc/class-bfa-release-data-v2-adapter.php</file>
+    <file>inc/class-bfa-release-data-v2-refresher.php</file>
 
     <arg name="extensions" value="php"/>
     <arg name="colors"/>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,7 @@ parameters:
         - inc/class-bfa-release-channel.php
         - inc/class-bfa-release-data-v2-validator.php
         - inc/class-bfa-release-data-v2-adapter.php
+        - inc/class-bfa-release-data-v2-refresher.php
     treatPhpDocTypesAsCertain: false
     reportUnmatchedIgnoredErrors: true
 

--- a/tests/BfalTestCase.php
+++ b/tests/BfalTestCase.php
@@ -24,6 +24,7 @@ abstract class BfalTestCase extends TestCase {
 
 	protected function get_instance( $args = array() ) {
 		$this->prime_valid_transient();
+		$args = array_merge( array( 'release_channel' => '5.x' ), $args );
 		return Better_Font_Awesome_Library::get_instance( $args );
 	}
 

--- a/tests/FallbackBaselineTest.php
+++ b/tests/FallbackBaselineTest.php
@@ -29,7 +29,7 @@ class FallbackBaselineTest extends TestCase {
 		$this->assertSame( $expected, $this->get_inventory() );
 	}
 
-	public function test_fallback_metadata_is_a_valid_inactive_schema_2_record() {
+	public function test_fallback_metadata_is_a_valid_schema_2_record() {
 		$result = Better_Font_Awesome_Release_Data_V2_Validator::parse_record_json(
 			file_get_contents( $this->fallback_root . '/metadata.json' )
 		);
@@ -149,12 +149,12 @@ class FallbackBaselineTest extends TestCase {
 		$this->assertStringEndsWith( "\n", file_get_contents( $this->fallback_root . '/provenance.json' ) );
 	}
 
-	public function test_inactive_fallback_does_not_replace_font_awesome_5_runtime_fallback() {
+	public function test_packaged_fallback_is_the_default_font_awesome_7_runtime_baseline() {
 		$runtime = file_get_contents( dirname( __DIR__ ) . '/better-font-awesome-library.php' );
 
 		$this->assertSame( 'inc/fallback-release-data.json', Better_Font_Awesome_Library::FALLBACK_RELEASE_DATA_PATH );
-		$this->assertSame( '5.x', Better_Font_Awesome_Library::get_instance()->get_release_channel() );
-		$this->assertStringNotContainsString( 'font-awesome-7-fallback', $runtime );
+		$this->assertSame( '7.x', Better_Font_Awesome_Library::get_instance()->get_release_channel() );
+		$this->assertStringContainsString( 'font-awesome-7-fallback', $runtime );
 		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
 	}
 

--- a/tests/FontAwesome7RefreshTest.php
+++ b/tests/FontAwesome7RefreshTest.php
@@ -23,10 +23,17 @@ class FontAwesome7RefreshTest extends BfalTestCase {
 		$this->assertSame( 18, $GLOBALS['bfa_test_http_calls'] );
 		$this->assertSame( array(), $GLOBALS['bfa_test_transient_writes'] );
 		$this->assertSame( array(), $GLOBALS['bfa_test_transients'] );
+		$this->assertSame( $result, $library->get_release_record() );
+		$this->assertSame( $result['release']['srisByLicense']['free'], $library->get_release_assets() );
 		$this->assertSame( '7.3.2', $library->get_version() );
 		$this->assertSame(
 			'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.3.2/css/all.min.css',
 			$library->get_stylesheet_url()
+		);
+		$tag = '<link rel="stylesheet" id="bfa-font-awesome-css" href="remote.css" />';
+		$this->assertStringContainsString(
+			'integrity="' . $result['release']['srisByLicense']['free'][0]['value'] . '"',
+			apply_filters( 'style_loader_tag', $tag, 'bfa-font-awesome' )
 		);
 	}
 
@@ -37,6 +44,10 @@ class FontAwesome7RefreshTest extends BfalTestCase {
 			return $this->http_response( 200, $this->metadata_body( '7.3.1' ) );
 		};
 		$library = Better_Font_Awesome_Library::get_instance();
+		$this->assertSame(
+			'https://example.test/plugin/inc/font-awesome-7-fallback/css/all.min.css',
+			$library->get_stylesheet_url()
+		);
 
 		$result = $library->refresh_release_data();
 
@@ -44,6 +55,11 @@ class FontAwesome7RefreshTest extends BfalTestCase {
 		$this->assertSame( 'fallback', $result['source'] );
 		$this->assertSame( 1, $GLOBALS['bfa_test_http_calls'] );
 		$this->assertSame( array(), $GLOBALS['bfa_test_transient_writes'] );
+		$this->assertSame(
+			'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.3.1/css/all.min.css',
+			$library->get_stylesheet_url()
+		);
+		$this->assertSame( $result['release']['srisByLicense']['free'], $library->get_release_assets() );
 	}
 
 	public function test_worker_enforces_exact_request_and_resource_budget_contract() {

--- a/tests/FontAwesome7RefreshTest.php
+++ b/tests/FontAwesome7RefreshTest.php
@@ -1,0 +1,264 @@
+<?php
+
+require_once __DIR__ . '/BfalTestCase.php';
+
+class FontAwesome7RefreshTest extends BfalTestCase {
+	public function test_successful_new_candidate_returns_complete_record_without_bfal_persistence() {
+		$assets = $this->get_asset_bodies();
+		$this->install_successful_responses( '7.3.2', $assets );
+		$library = Better_Font_Awesome_Library::get_instance();
+
+		$result = $library->refresh_release_data();
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 2, $result['schema_version'] );
+		$this->assertSame( '7.x', $result['channel'] );
+		$this->assertSame( 'free', $result['edition'] );
+		$this->assertSame( 'api', $result['source'] );
+		$this->assertSame( '7.3.2', $result['release']['version'] );
+		$this->assertSame(
+			'sha512-' . base64_encode( hash( 'sha512', $assets['css/all.min.css'], true ) ),
+			$result['release']['srisByLicense']['free'][0]['value']
+		);
+		$this->assertSame( 18, $GLOBALS['bfa_test_http_calls'] );
+		$this->assertSame( array(), $GLOBALS['bfa_test_transient_writes'] );
+		$this->assertSame( array(), $GLOBALS['bfa_test_transients'] );
+		$this->assertSame( '7.3.2', $library->get_version() );
+		$this->assertSame(
+			'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.3.2/css/all.min.css',
+			$library->get_stylesheet_url()
+		);
+	}
+
+	public function test_already_current_record_stops_after_metadata_discovery() {
+		$GLOBALS['bfa_test_http_callback'] = function ( $method, $url ) {
+			$this->assertSame( 'POST', $method );
+			$this->assertSame( Better_Font_Awesome_Library::FONT_AWESOME_API_BASE_URL, $url );
+			return $this->http_response( 200, $this->metadata_body( '7.3.1' ) );
+		};
+		$library = Better_Font_Awesome_Library::get_instance();
+
+		$result = $library->refresh_release_data();
+
+		$this->assertSame( '7.3.1', $result['release']['version'] );
+		$this->assertSame( 'fallback', $result['source'] );
+		$this->assertSame( 1, $GLOBALS['bfa_test_http_calls'] );
+		$this->assertSame( array(), $GLOBALS['bfa_test_transient_writes'] );
+	}
+
+	public function test_worker_enforces_exact_request_and_resource_budget_contract() {
+		$this->install_successful_responses( '7.3.2', $this->get_asset_bodies() );
+		Better_Font_Awesome_Library::get_instance()->refresh_release_data();
+
+		$this->assertSame( 18, Better_Font_Awesome_Release_Data_V2_Refresher::MAX_REQUESTS );
+		$this->assertSame( 4 * 1024 * 1024, Better_Font_Awesome_Release_Data_V2_Refresher::MAX_TOTAL_BYTES );
+		$this->assertSame( 30, Better_Font_Awesome_Release_Data_V2_Refresher::MAX_TOTAL_SECONDS );
+		$this->assertCount( 18, $GLOBALS['bfa_test_http_requests'] );
+		foreach ( $GLOBALS['bfa_test_http_requests'] as $request ) {
+			$this->assertTrue( $request['args']['sslverify'] );
+			$this->assertSame( 0, $request['args']['redirection'] );
+			$this->assertTrue( $request['args']['reject_unsafe_urls'] );
+			$this->assertTrue( $request['args']['blocking'] );
+			$this->assertLessThanOrEqual( 5, $request['args']['timeout'] );
+			$this->assertLessThanOrEqual( Better_Font_Awesome_Release_Data_V2_Refresher::MAX_TOTAL_BYTES, $request['args']['limit_response_size'] );
+		}
+	}
+
+	public function test_malformed_metadata_retains_the_bundled_current_record() {
+		$GLOBALS['bfa_test_http_response'] = $this->http_response( 200, '{invalid' );
+		$library = Better_Font_Awesome_Library::get_instance();
+
+		$result = $library->refresh_release_data();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'bfa_v2_invalid_json', $result->get_error_code() );
+		$this->assertSame( '7.3.1', $library->get_version() );
+		$this->assertSame( 'fallback', $library->get_release_record()['source'] );
+		$this->assertSame( array(), $GLOBALS['bfa_test_transient_writes'] );
+	}
+
+	public function test_provider_disagreement_rejects_the_complete_candidate() {
+		$assets = $this->get_asset_bodies();
+		$this->install_successful_responses(
+			'7.3.2',
+			$assets,
+			function ( $method, $url, $body, $path ) {
+				if ( false !== strpos( $url, 'cdn.jsdelivr.net' ) && 'css/all.min.css' === $path ) {
+					return $body . 'different';
+				}
+				return $body;
+			}
+		);
+		$library = Better_Font_Awesome_Library::get_instance();
+
+		$result = $library->refresh_release_data();
+
+		$this->assertSame( 'bfa_v2_provider_disagreement', $result->get_error_code() );
+		$this->assertSame( '7.3.1', $library->get_version() );
+		$this->assertSame( array(), $GLOBALS['bfa_test_transient_writes'] );
+	}
+
+	public function test_invalid_css_font_reference_rejects_the_candidate() {
+		$assets = $this->get_asset_bodies();
+		$assets['css/all.min.css'] = str_replace( 'fa-v4compatibility.woff2', 'fa-evil.woff2', $assets['css/all.min.css'] );
+		$this->install_successful_responses( '7.3.2', $assets );
+
+		$result = Better_Font_Awesome_Library::get_instance()->refresh_release_data();
+
+		$this->assertSame( 'bfa_v2_font_reference_invalid', $result->get_error_code() );
+		$this->assertSame( array(), $GLOBALS['bfa_test_transient_writes'] );
+	}
+
+	public function test_redirected_asset_is_a_publication_lag_failure() {
+		$assets = $this->get_asset_bodies();
+		$this->install_successful_responses(
+			'7.3.2',
+			$assets,
+			function ( $method, $url, $body, $path ) {
+				if ( false !== strpos( $url, 'cdnjs.cloudflare.com' ) && 'css/v4-shims.min.css' === $path ) {
+					return $this->http_response( 302, '' );
+				}
+				return $body;
+			}
+		);
+
+		$result = Better_Font_Awesome_Library::get_instance()->refresh_release_data();
+
+		$this->assertSame( 'bfa_v2_publication_lag', $result->get_error_code() );
+		$this->assertSame( 0, $GLOBALS['bfa_test_last_http_request']['args']['redirection'] );
+	}
+
+	public function test_missing_required_asset_rejects_the_candidate() {
+		$assets = $this->get_asset_bodies();
+		$this->install_successful_responses(
+			'7.3.2',
+			$assets,
+			function ( $method, $url, $body, $path ) {
+				if ( false !== strpos( $url, 'cdnjs.cloudflare.com' ) && 'webfonts/fa-solid-900.woff2' === $path ) {
+					return $this->http_response( 404, '' );
+				}
+				return $body;
+			}
+		);
+
+		$result = Better_Font_Awesome_Library::get_instance()->refresh_release_data();
+
+		$this->assertSame( 'bfa_v2_publication_lag', $result->get_error_code() );
+		$this->assertSame( '7.3.1', Better_Font_Awesome_Library::get_instance()->get_version() );
+		$this->assertSame( array(), $GLOBALS['bfa_test_transient_writes'] );
+	}
+
+	public function test_timeout_is_sanitized_and_recovery_succeeds_on_the_next_attempt() {
+		$GLOBALS['bfa_test_http_response'] = new WP_Error( 'http_request_failed', '<script>secret timeout</script>' );
+		$library = Better_Font_Awesome_Library::get_instance();
+
+		$failed = $library->refresh_release_data();
+		$this->assertSame( 'bfa_v2_transport_error', $failed->get_error_code() );
+		$this->assertStringNotContainsString( 'secret', $failed->get_error_message() );
+
+		$this->install_successful_responses( '7.3.2', $this->get_asset_bodies() );
+		$recovered = $library->refresh_release_data();
+
+		$this->assertSame( '7.3.2', $recovered['release']['version'] );
+		$this->assertSame( '', $library->get_error( 'api' ) );
+		$this->assertSame( array(), $GLOBALS['bfa_test_transient_writes'] );
+	}
+
+	public function test_metadata_response_limit_fails_closed() {
+		$GLOBALS['bfa_test_http_response'] = $this->http_response(
+			200,
+			str_repeat( 'x', Better_Font_Awesome_Release_Data_V2_Refresher::MAX_METADATA_BYTES )
+		);
+
+		$result = Better_Font_Awesome_Library::get_instance()->refresh_release_data();
+
+		$this->assertSame( 'bfa_v2_response_too_large', $result->get_error_code() );
+		$this->assertSame( '7.3.1', Better_Font_Awesome_Library::get_instance()->get_version() );
+	}
+
+	public function test_exact_npm_version_publication_lag_stops_before_asset_downloads() {
+		$GLOBALS['bfa_test_http_callback'] = function ( $method, $url ) {
+			if ( 'POST' === $method ) {
+				return $this->http_response( 200, $this->metadata_body( '7.3.2' ) );
+			}
+			$this->assertStringContainsString( 'registry.npmjs.org', $url );
+			return $this->http_response( 404, '' );
+		};
+
+		$result = Better_Font_Awesome_Library::get_instance()->refresh_release_data();
+
+		$this->assertSame( 'bfa_v2_publication_lag', $result->get_error_code() );
+		$this->assertSame( 2, $GLOBALS['bfa_test_http_calls'] );
+	}
+
+	private function install_successful_responses( $version, $assets, $mutate = null ) {
+		$GLOBALS['bfa_test_http_callback'] = function ( $method, $url, $args ) use ( $version, $assets, $mutate ) {
+			if ( 'POST' === $method ) {
+				$this->assertSame( Better_Font_Awesome_Library::FONT_AWESOME_API_BASE_URL, $url );
+				$query = json_decode( $args['body'], true );
+				$this->assertStringContainsString( 'release(version: "7.x")', $query['query'] );
+				$this->assertStringContainsString( 'icons(license: "free")', $query['query'] );
+				return $this->http_response( 200, $this->metadata_body( $version ) );
+			}
+
+			if ( false !== strpos( $url, 'registry.npmjs.org' ) ) {
+				return $this->http_response(
+					200,
+					json_encode(
+						array(
+							'name'    => '@fortawesome/fontawesome-free',
+							'version' => $version,
+							'license' => '(CC-BY-4.0 AND OFL-1.1 AND MIT)',
+						)
+					)
+				);
+			}
+
+			foreach ( $assets as $path => $body ) {
+				if ( substr( $url, -strlen( $path ) ) !== $path ) {
+					continue;
+				}
+
+				$value = is_callable( $mutate ) ? call_user_func( $mutate, $method, $url, $body, $path ) : $body;
+				if ( is_array( $value ) || is_wp_error( $value ) ) {
+					return $value;
+				}
+				return $this->http_response( 200, $value );
+			}
+
+			return new WP_Error( 'unexpected_http', 'Unexpected HTTP request.' );
+		};
+	}
+
+	private function metadata_body( $version ) {
+		$fixture            = json_decode( file_get_contents( __DIR__ . '/fixtures/font-awesome-7.3.1.json' ), true );
+		$release            = $fixture['data']['release'];
+		$release['version'] = $version;
+		unset( $release['srisByLicense'] );
+
+		return json_encode( array( 'data' => array( 'release' => $release ) ) );
+	}
+
+	private function get_asset_bodies() {
+		return array(
+			'css/all.min.css'                   => '.all{src:url(../webfonts/fa-brands-400.woff2)}.regular{src:url(../webfonts/fa-regular-400.woff2)}.solid{src:url(../webfonts/fa-solid-900.woff2)}.v4{src:url(../webfonts/fa-v4compatibility.woff2)}',
+			'css/v4-font-face.min.css'          => '.v4{src:url(../webfonts/fa-v4compatibility.woff2)}',
+			'css/v4-shims.min.css'              => '.shim{display:inline-block}',
+			'css/v5-font-face.min.css'          => '.v5{src:url(../webfonts/fa-solid-900.woff2)}',
+			'webfonts/fa-brands-400.woff2'      => 'brands-font',
+			'webfonts/fa-regular-400.woff2'     => 'regular-font',
+			'webfonts/fa-solid-900.woff2'       => 'solid-font',
+			'webfonts/fa-v4compatibility.woff2' => 'v4-font',
+		);
+	}
+
+	private function http_response( $status, $body ) {
+		return array(
+			'response' => array(
+				'code'    => $status,
+				'message' => 'Mock response',
+			),
+			'body' => $body,
+		);
+	}
+}

--- a/tests/FontAwesome7RuntimeTest.php
+++ b/tests/FontAwesome7RuntimeTest.php
@@ -104,6 +104,45 @@ class FontAwesome7RuntimeTest extends BfalTestCase {
 		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
 	}
 
+	public function test_provider_fallback_provenance_does_not_select_packaged_assets() {
+		$record = $this->get_schema_two_record( '7.4.0', 'provider-record' );
+		$library = Better_Font_Awesome_Library::get_instance(
+			array(
+				'release_data_provider' => function () use ( $record ) {
+					return $record;
+				},
+			)
+		);
+		$integrity = $record['release']['srisByLicense']['free'][0]['value'];
+		$tag       = '<link rel="stylesheet" id="bfa-font-awesome-css" href="remote.css" />';
+
+		$this->assertSame( 'fallback', $library->get_release_record()['source'] );
+		$this->assertSame( '7.4.0', $library->get_version() );
+		$this->assertSame(
+			'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.4.0/css/all.min.css',
+			$library->get_stylesheet_url()
+		);
+		$this->assertSame( $record['release']['srisByLicense']['free'], $library->get_release_assets() );
+		$this->assertStringContainsString( 'integrity="' . $integrity . '"', apply_filters( 'style_loader_tag', $tag, 'bfa-font-awesome' ) );
+		$this->assertStringNotContainsString( '/font-awesome-7-fallback/', $library->get_stylesheet_url() );
+	}
+
+	public function test_transient_fallback_provenance_does_not_select_packaged_assets() {
+		$record = $this->get_schema_two_record( '7.4.1', 'transient-record' );
+		$GLOBALS['bfa_test_transients']['bfa-release-data'] = $record;
+
+		$library = Better_Font_Awesome_Library::get_instance();
+
+		$this->assertSame( 'fallback', $library->get_release_record()['source'] );
+		$this->assertSame( '7.4.1', $library->get_version() );
+		$this->assertSame(
+			'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.4.1/css/all.min.css',
+			$library->get_stylesheet_url()
+		);
+		$this->assertSame( $record['release']['srisByLicense']['free'], $library->get_release_assets() );
+		$this->assertStringNotContainsString( '/font-awesome-7-fallback/', $library->get_stylesheet_url() );
+	}
+
 	public function test_explicit_five_rejects_a_schema_two_provider_record() {
 		$record = Better_Font_Awesome_Release_Data_V2_Validator::parse_record_json(
 			file_get_contents( dirname( __DIR__ ) . '/inc/font-awesome-7-fallback/metadata.json' )
@@ -229,6 +268,19 @@ class FontAwesome7RuntimeTest extends BfalTestCase {
 			'v4'      => $library->get_stylesheet_url_v4_shim(),
 			'assets'  => $library->get_release_assets(),
 		);
+	}
+
+	private function get_schema_two_record( $version, $seed ) {
+		$record = Better_Font_Awesome_Release_Data_V2_Validator::parse_record_json(
+			file_get_contents( dirname( __DIR__ ) . '/inc/font-awesome-7-fallback/metadata.json' )
+		)['record'];
+		$record['release']['version'] = $version;
+		foreach ( $record['release']['srisByLicense']['free'] as &$asset ) {
+			$asset['value'] = 'sha512-' . base64_encode( hash( 'sha512', $seed . ':' . $asset['path'], true ) );
+		}
+		unset( $asset );
+
+		return $record;
 	}
 
 	private function reset_library_singleton() {

--- a/tests/FontAwesome7RuntimeTest.php
+++ b/tests/FontAwesome7RuntimeTest.php
@@ -87,6 +87,59 @@ class FontAwesome7RuntimeTest extends BfalTestCase {
 		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
 	}
 
+	/**
+	 * @dataProvider invalid_release_channel_provider
+	 */
+	public function test_invalid_release_channel_argument_fails_closed_and_remains_immutable( $invalid_channel ) {
+		$provider_calls   = 0;
+		$refresh_requests = 0;
+		$this->prime_valid_transient();
+		$first = Better_Font_Awesome_Library::get_instance(
+			array(
+				'release_channel'               => $invalid_channel,
+				'release_data_provider'         => function () use ( &$provider_calls ) {
+					++$provider_calls;
+					return array();
+				},
+				'release_data_refresh_callback' => function () use ( &$refresh_requests ) {
+					++$refresh_requests;
+				},
+			)
+		);
+		$later = Better_Font_Awesome_Library::get_instance( array( 'release_channel' => '5.x' ) );
+
+		$this->assertSame( $first, $later );
+		$this->assertSame( '', $first->get_release_channel() );
+		$this->assertSame( '', $first->get_version() );
+		$this->assertSame( '', $first->get_stylesheet_url() );
+		$this->assertSame( '', $first->get_stylesheet_url_v4_shim() );
+		$this->assertSame( array(), $first->get_release_record() );
+		$this->assertSame( array(), $first->get_release_icons() );
+		$this->assertSame( array(), $first->get_release_assets() );
+		$this->assertSame( array(), $first->get_icons() );
+		$this->assertSame( array(), $GLOBALS['bfa_test_editor_styles'] );
+
+		$first->request_release_data_refresh();
+		do_action( 'wp_enqueue_scripts' );
+		$this->assertSame( array(), $GLOBALS['bfa_test_enqueued_styles'] );
+		$this->assertSame( 0, $provider_calls );
+		$this->assertSame( 0, $refresh_requests );
+		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
+
+		$error = $first->get_error( 'channel' );
+		$this->assertInstanceOf( WP_Error::class, $error );
+		$this->assertSame( 'bfa_channel_unsupported', $error->get_error_code() );
+		$this->assertSame( $error, $first->refresh_release_data() );
+	}
+
+	public function invalid_release_channel_provider() {
+		return array(
+			'wrong case'        => array( '5.X' ),
+			'unsupported major' => array( '6.x' ),
+			'null'              => array( null ),
+		);
+	}
+
 	public function test_wrong_channel_provider_cannot_mix_metadata_and_assets() {
 		$fa5 = $this->get_valid_release();
 		$library = Better_Font_Awesome_Library::get_instance(

--- a/tests/FontAwesome7RuntimeTest.php
+++ b/tests/FontAwesome7RuntimeTest.php
@@ -1,0 +1,241 @@
+<?php
+
+require_once __DIR__ . '/BfalTestCase.php';
+
+class FontAwesome7RuntimeTest extends BfalTestCase {
+	public function test_implicit_default_and_explicit_seven_selection_are_identical() {
+		$implicit = Better_Font_Awesome_Library::get_instance();
+		$first    = $this->runtime_snapshot( $implicit );
+
+		$this->reset_library_singleton();
+		bfa_test_reset_wordpress_state();
+		$explicit = Better_Font_Awesome_Library::get_instance( array( 'release_channel' => '7.x' ) );
+
+		$this->assertSame( $first, $this->runtime_snapshot( $explicit ) );
+		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
+	}
+
+	public function test_default_seven_uses_packaged_fallback_immediately_without_http() {
+		$library = Better_Font_Awesome_Library::get_instance( array( 'include_v4_shim' => true ) );
+
+		$this->assertSame( '7.x', $library->get_release_channel() );
+		$this->assertSame( '7.3.1', $library->get_version() );
+		$this->assertSame( 'fallback', $library->get_release_record()['source'] );
+		$this->assertSame(
+			'https://example.test/plugin/inc/font-awesome-7-fallback/css/all.min.css',
+			$library->get_stylesheet_url()
+		);
+		$this->assertSame(
+			'https://example.test/plugin/inc/font-awesome-7-fallback/css/v4-shims.min.css',
+			$library->get_stylesheet_url_v4_shim()
+		);
+		$this->assertCount( 4, $library->get_release_assets() );
+		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
+		$this->assertSame( array(), $GLOBALS['bfa_test_transient_writes'] );
+	}
+
+	public function test_first_caller_channel_is_immutable_across_later_callers_and_loads() {
+		$filter_calls = 0;
+		add_filter(
+			'bfa_font_awesome_release_channel',
+			function ( $channel ) use ( &$filter_calls ) {
+				++$filter_calls;
+				return 1 === $filter_calls ? $channel : '5.x';
+			}
+		);
+
+		$first  = Better_Font_Awesome_Library::get_instance();
+		$second = Better_Font_Awesome_Library::get_instance( array( 'release_channel' => '5.x' ) );
+		$first->load();
+
+		$this->assertSame( $first, $second );
+		$this->assertSame( '7.x', $first->get_release_channel() );
+		$this->assertSame( '7.3.1', $first->get_version() );
+		$this->assertSame( 1, $filter_calls );
+	}
+
+	public function test_explicit_five_first_caller_cannot_be_overridden_by_later_seven_caller() {
+		$this->prime_valid_transient();
+		$first  = Better_Font_Awesome_Library::get_instance( array( 'release_channel' => '5.x' ) );
+		$second = Better_Font_Awesome_Library::get_instance( array( 'release_channel' => '7.x' ) );
+
+		$this->assertSame( $first, $second );
+		$this->assertSame( '5.x', $second->get_release_channel() );
+		$this->assertSame( '5.15.4', $second->get_version() );
+		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
+	}
+
+	public function test_explicit_five_preserves_established_runtime_behavior() {
+		$this->prime_valid_transient();
+		$library = Better_Font_Awesome_Library::get_instance( array( 'release_channel' => '5.x' ) );
+
+		$this->assertSame( '5.x', $library->get_release_channel() );
+		$this->assertSame( '5.15.4', $library->get_version() );
+		$this->assertSame( 'https://use.fontawesome.com/releases/v5.15.4/css/all.css', $library->get_stylesheet_url() );
+		$this->assertSame( 'https://use.fontawesome.com/releases/v5.15.4/css/v4-shims.css', $library->get_stylesheet_url_v4_shim() );
+		$this->assertSame(
+			'<i class="fas fa-moon fa-2x fa-spin my-custom-class " ></i>',
+			$library->render_shortcode(
+				array(
+					'name'             => 'moon',
+					'style'            => 'solid',
+					'class'            => '2x spin',
+					'unprefixed_class' => 'my-custom-class',
+				)
+			)
+		);
+		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
+	}
+
+	public function test_wrong_channel_provider_cannot_mix_metadata_and_assets() {
+		$fa5 = $this->get_valid_release();
+		$library = Better_Font_Awesome_Library::get_instance(
+			array(
+				'release_data_provider' => function () use ( $fa5 ) {
+					return $fa5;
+				},
+			)
+		);
+
+		$this->assertSame( '7.3.1', $library->get_version() );
+		$this->assertSame( 'fallback', $library->get_release_record()['source'] );
+		$this->assertStringContainsString( '/font-awesome-7-fallback/', $library->get_stylesheet_url() );
+		$this->assertSame( 'bfa_v2_version_unsupported', $library->get_error( 'provider' )->get_error_code() );
+		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
+	}
+
+	public function test_explicit_five_rejects_a_schema_two_provider_record() {
+		$record = Better_Font_Awesome_Release_Data_V2_Validator::parse_record_json(
+			file_get_contents( dirname( __DIR__ ) . '/inc/font-awesome-7-fallback/metadata.json' )
+		)['record'];
+		$library = Better_Font_Awesome_Library::get_instance(
+			array(
+				'release_channel'       => '5.x',
+				'release_data_provider' => function () use ( $record ) {
+					return $record;
+				},
+			)
+		);
+
+		$this->assertSame( '5.x', $library->get_release_channel() );
+		$this->assertSame( '5.14.0', $library->get_version() );
+		$this->assertSame( 'fallback', $library->get_release_record()['source'] );
+		$this->assertSame( 'bfa_record_schema_unsupported', $library->get_error( 'provider' )->get_error_code() );
+		$this->assertSame( 'https://use.fontawesome.com/releases/v5.14.0/css/all.css', $library->get_stylesheet_url() );
+	}
+
+	public function test_schema_two_icons_adapt_to_the_established_public_shape_and_aliases() {
+		$library = Better_Font_Awesome_Library::get_instance();
+		$icons   = $library->get_release_icons();
+		$address = null;
+		foreach ( $icons as $icon ) {
+			if ( 'address-book' === $icon['id'] ) {
+				$address = $icon;
+				break;
+			}
+		}
+
+		$this->assertSame( array( 'id', 'label', 'membership', 'styles' ), array_keys( $address ) );
+		$this->assertSame( array( 'regular', 'solid' ), $address['membership']['free'] );
+		$this->assertSame( array( 'regular', 'solid' ), $address['styles'] );
+		$github = null;
+		foreach ( $icons as $icon ) {
+			if ( 'github' === $icon['id'] ) {
+				$github = $icon;
+				break;
+			}
+		}
+		$this->assertSame( array( 'brands' ), $github['membership']['free'] );
+
+		$picker = null;
+		foreach ( $library->get_icons() as $icon ) {
+			if ( 'address-book' === $icon['slug'] && 'solid' === $icon['style'] ) {
+				$picker = $icon;
+				break;
+			}
+		}
+
+		$this->assertSame( array( 'title', 'slug', 'style', 'base_class', 'searchTerms' ), array_keys( $picker ) );
+		$this->assertSame( 'fas fa-address-book', $picker['base_class'] );
+		$this->assertStringContainsString( 'contact-book', $picker['searchTerms'] );
+		$this->assertSame(
+			'<i class="fas fa-address-book " ></i>',
+			$library->render_shortcode( array( 'name' => 'contact-book', 'style' => 'solid' ) )
+		);
+	}
+
+	public function test_seven_registers_only_required_runtime_and_compatibility_styles() {
+		$library = Better_Font_Awesome_Library::get_instance( array( 'include_v4_shim' => true ) );
+		$library->register_font_awesome_css();
+
+		$this->assertSame(
+			array(
+				'bfa-font-awesome',
+				'bfa-font-awesome-v5-compat',
+				'bfa-font-awesome-v4-font-face',
+				'bfa-font-awesome-v4-shim',
+			),
+			array_keys( $GLOBALS['bfa_test_registered_styles'] )
+		);
+		$this->assertStringEndsWith( '/css/v5-font-face.min.css', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome-v5-compat']['src'] );
+		$this->assertStringEndsWith( '/css/v4-font-face.min.css', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome-v4-font-face']['src'] );
+		$this->assertArrayNotHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_inline_styles'] );
+
+		$this->assertSame(
+			array(
+				'https://example.test/plugin/inc/font-awesome-7-fallback/css/all.min.css',
+				'https://example.test/plugin/inc/font-awesome-7-fallback/css/v5-font-face.min.css',
+				'https://example.test/plugin/inc/font-awesome-7-fallback/css/v4-font-face.min.css',
+				'https://example.test/plugin/inc/font-awesome-7-fallback/css/v4-shims.min.css',
+			),
+			get_editor_stylesheets()
+		);
+	}
+
+	public function test_seven_stylesheet_tags_use_matching_sri_and_anonymous_cors() {
+		$library   = Better_Font_Awesome_Library::get_instance();
+		$integrity = $library->get_release_assets()[0]['value'];
+		$tag       = '<link rel="stylesheet" id="bfa-font-awesome-css" href="local.css" />';
+		$filtered  = apply_filters( 'style_loader_tag', $tag, 'bfa-font-awesome' );
+
+		$this->assertStringContainsString( 'crossorigin="anonymous"', $filtered );
+		$this->assertStringContainsString( 'integrity="' . $integrity . '"', $filtered );
+	}
+
+	public function test_every_ordinary_seven_entrypoint_performs_zero_http() {
+		$library = Better_Font_Awesome_Library::get_instance( array( 'include_v4_shim' => true ) );
+
+		$library->load();
+		$library->get_version();
+		$library->get_stylesheet_url();
+		$library->get_stylesheet_url_v4_shim();
+		$library->get_icons();
+		$library->get_release_icons();
+		$library->get_release_assets();
+		$library->register_font_awesome_css();
+		$library->add_editor_styles();
+		$library->enqueue_admin_scripts();
+		$library->render_shortcode( array( 'name' => 'close' ) );
+
+		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
+	}
+
+	private function runtime_snapshot( $library ) {
+		return array(
+			'channel' => $library->get_release_channel(),
+			'version' => $library->get_version(),
+			'source'  => $library->get_release_record()['source'],
+			'main'    => $library->get_stylesheet_url(),
+			'v4'      => $library->get_stylesheet_url_v4_shim(),
+			'assets'  => $library->get_release_assets(),
+		);
+	}
+
+	private function reset_library_singleton() {
+		$property = new ReflectionProperty( Better_Font_Awesome_Library::class, 'instance' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( null, null );
+	}
+}

--- a/tests/ReleaseDataRuntimeTest.php
+++ b/tests/ReleaseDataRuntimeTest.php
@@ -3,6 +3,16 @@
 require_once __DIR__ . '/BfalTestCase.php';
 
 class ReleaseDataRuntimeTest extends BfalTestCase {
+	protected function setUp(): void {
+		parent::setUp();
+		add_filter(
+			'bfa_font_awesome_release_channel',
+			function () {
+				return '5.x';
+			}
+		);
+	}
+
 	public function test_missing_data_returns_fallback_without_transport_and_requests_refresh() {
 		$requests = array();
 		$library  = Better_Font_Awesome_Library::get_instance(

--- a/tests/ReleaseDataRuntimeTest.php
+++ b/tests/ReleaseDataRuntimeTest.php
@@ -383,10 +383,19 @@ class ReleaseDataRuntimeTest extends BfalTestCase {
 				return '6.x';
 			}
 		);
-		$result = Better_Font_Awesome_Library::get_instance()->refresh_release_data();
+		$library = Better_Font_Awesome_Library::get_instance();
+		$later   = Better_Font_Awesome_Library::get_instance( array( 'release_channel' => '5.x' ) );
+		$error   = $library->get_error( 'channel' );
 
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'bfa_channel_unsupported', $result->get_error_code() );
+		$this->assertSame( $library, $later );
+		$this->assertSame( '', $library->get_release_channel() );
+		$this->assertSame( '', $library->get_version() );
+		$this->assertSame( '', $library->get_stylesheet_url() );
+		$this->assertSame( array(), $library->get_release_record() );
+		$this->assertSame( array(), $GLOBALS['bfa_test_editor_styles'] );
+		$this->assertInstanceOf( WP_Error::class, $error );
+		$this->assertSame( 'bfa_channel_unsupported', $error->get_error_code() );
+		$this->assertSame( $error, $library->refresh_release_data() );
 		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -106,6 +106,8 @@ function bfa_test_reset_wordpress_state() {
 	$GLOBALS['bfa_test_enqueued_styles']  = array();
 	$GLOBALS['bfa_test_filter_callbacks'] = array();
 	$GLOBALS['bfa_test_http_calls']       = 0;
+	$GLOBALS['bfa_test_http_callback']    = null;
+	$GLOBALS['bfa_test_http_requests']    = array();
 	$GLOBALS['bfa_test_http_response']    = new WP_Error( 'unexpected_http', 'Unexpected HTTP request.' );
 	$GLOBALS['bfa_test_inline_styles']    = array();
 	$GLOBALS['bfa_test_has_current_screen'] = true;
@@ -322,8 +324,20 @@ function wp_json_encode( $value ) {
 }
 
 function wp_remote_post( $url, $args ) {
+	return bfa_test_http_request( 'POST', $url, $args );
+}
+
+function wp_remote_get( $url, $args ) {
+	return bfa_test_http_request( 'GET', $url, $args );
+}
+
+function bfa_test_http_request( $method, $url, $args ) {
 	++$GLOBALS['bfa_test_http_calls'];
-	$GLOBALS['bfa_test_last_http_request'] = compact( 'url', 'args' );
+	$GLOBALS['bfa_test_last_http_request'] = compact( 'method', 'url', 'args' );
+	$GLOBALS['bfa_test_http_requests'][]   = $GLOBALS['bfa_test_last_http_request'];
+	if ( is_callable( $GLOBALS['bfa_test_http_callback'] ) ) {
+		return call_user_func( $GLOBALS['bfa_test_http_callback'], $method, $url, $args );
+	}
 	return $GLOBALS['bfa_test_http_response'];
 }
 


### PR DESCRIPTION
## Summary

This PR implements the smallest BFAL runtime tranche needed for Font Awesome 7 Free, building directly on merged PR #46.

- Resolves one immutable `release_channel` during first-caller singleton initialization.
- Defaults the next major BFAL runtime to `7.x`.
- Preserves explicit `release_channel => '5.x'` for the BFAL 2.x-compatible runtime.
- Makes implicit 7.x and explicit 7.x behavior identical.
- Fails closed with a sanitized error when the first caller or channel filter supplies an unsupported value.
- Immediately validates and serves the packaged Font Awesome Free 7.3.1 fallback without HTTP, cron, migration, persistence, pending state, or settings.
- Adapts schema-2 family and style metadata to BFAL's established public icon shape, including canonical alias resolution.
- Loads only the packaged all, v5 font-face, and optional v4 compatibility styles needed by the established runtime behavior.
- Uses matching schema-2 SRI values on Font Awesome 7 WordPress stylesheet tags.
- Rejects provider and transient records from the wrong channel before falling back safely.
- Extends the existing explicit refresh method with one bounded Font Awesome 7 worker attempt and no BFAL persistence.

## Release-line contract

BFAL 2.x remains the existing Font Awesome 5-compatible release line. This implementation changes the implicit default and therefore must not be published under a BFAL 2.x tag.

This work is foundation for the next major BFAL release. This PR intentionally does not bump `Better_Font_Awesome_Library::VERSION`, npm versions, tags, or release notes. A separate reviewed release-preparation change must assign the appropriate next major BFAL version and update every version surface before publication.

Font Awesome 8 is not selected or discovered. Another Font Awesome major requires another reviewed BFAL compatibility release.

## Initialization API delta

```php
Better_Font_Awesome_Library::get_instance(
	array(
		'release_channel' => '7.x', // Next major BFAL default.
	)
);
```

Accepted values are `7.x` and `5.x`. The existing `bfa_font_awesome_release_channel` filter is applied once during first initialization. The resolved value is immutable, and later callers or filter changes cannot switch the instance. An unsupported resolved value records `bfa_channel_unsupported`, exposes no active channel, metadata, or stylesheet URLs, emits no refresh request, and cannot be replaced by a later caller.

## Immediate offline Font Awesome 7 behavior

The selected 7.x channel validates `inc/font-awesome-7-fallback/metadata.json` and immediately returns version 7.3.1. Runtime URLs are derived from the resolved BFAL installation URL and point to the packaged CSS and WOFF2 inventory only while BFAL's own packaged fallback record is active.

Record `source` remains provenance and is not used for asset routing. Provider, transient, and refreshed records use exact-version cdnjs URLs even if a validated record reports `source: fallback`. Focused tests bind each active record's metadata, version, URL, and SRI so assets cannot be mixed with the packaged 7.3.1 fallback.

Covered runtime surfaces include:

- main, v5 compatibility, v4 font-face, and v4 shim styles
- exact SRI values and anonymous CORS
- solid, regular, and brands picker rows
- schema-2 public icon adaptation
- canonical names and aliases
- editor styles
- shortcodes
- provider and transient routing provenance
- wrong-channel provider rejection
- zero HTTP across ordinary getters and request paths

## Explicit 7.x refresh contract

A same-version attempt performs one Font Awesome metadata request and reuses the complete validated current schema-2 record. After a successful explicit refresh, the active record uses its exact-version remote URLs. A failed refresh leaves the current record and its routing unchanged.

A genuinely newer candidate has these hard aggregate limits:

- 18 requests
- 4 MiB of response bodies
- 30 seconds overall
- 5 seconds maximum per request
- redirects disabled
- TLS verification required
- unsafe URLs rejected

The new-candidate request inventory is one Font Awesome GraphQL metadata request, one exact npm version request, eight exact-version cdnjs asset requests, and eight exact-version jsDelivr npm asset requests.

The worker validates Free Classic solid, regular, and brands metadata, aliases, the exact four CSS and four WOFF2 paths, exact npm identity and license, byte agreement across cdnjs and jsDelivr, CSS SRI, and CSS-to-font references. It returns one complete schema-2 record or a sanitized `WP_Error`.

BFAL does not persist 7.x refresh results. The consumer owns last-known-good storage, freshness, scheduling, locking, retries, and recovery.

## Font Awesome 5 compatibility proof

The existing BFAL compatibility and runtime tests now initialize explicit `5.x` where they assert BFAL 2.x behavior. They continue to prove the established release shape, CDN URLs, transient behavior, filters, handles, inline v4 shim behavior, picker data, editor styles, and byte-exact shortcodes.

Focused tests additionally prove that explicit 5.x cannot be overridden by a later 7.x caller and that a schema-2 provider record cannot mix with 5.x assets.

## Verification

- Font Awesome 7 runtime tests: 16 tests, 112 assertions
- Font Awesome 7 refresh tests: 11 tests, 218 assertions
- release data runtime tests: 37 tests, 167 assertions
- full PHPUnit suite: 169 tests, 4,941 assertions
- PHPCS: pass
- PHPStan: pass with no errors
- packaged fallback verification: 13 files verified for Font Awesome Free 7.3.1
- `git diff --check`: pass

No version bump, release archive, tag, publication, merge, or BFA integration is included in this correction.

## Remaining BFA integration work

This PR does not modify BFA. Before adoption of the next major BFAL release, BFA must be updated and reviewed to consume and persist complete schema-2 records, apply its WordPress-owned freshness and worker policy, handle the intentional default-major transition, and complete its own migration and browser acceptance work.

## Base and head

- Base: `e090cfbbbcf1749787830223dd759d9282594cde`
- Head: `c57c6a448e21b721fa491784235ba9eb947fd2ea`
