### PR TITLE
Prepare BFAL 3.0.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 3.0.0-rc.1
+
+- Prepared the BFAL 3 next-major release candidate for integration testing. BFAL now defaults to Font Awesome 7 Free when the first caller omits `release_channel`; no channel argument is required for the default.
+- Added explicit `release_channel => '5.x'` selection for consumers that need the legacy Font Awesome 5 channel. The first caller owns the selected channel for the singleton lifetime, and later callers cannot change it.
+- Made the packaged and verified Font Awesome Free 7.3.1 CSS, WOFF2, metadata, licensing, attribution, and provenance the immediate default baseline. Activation and ordinary frontend, admin, editor, REST, shortcode, picker, and getter paths require no metadata HTTP, cron run, migration, or delayed activation.
+- Added a bounded explicit 7.x background refresh operation that follows only newer, completely validated Font Awesome 7 Free releases. BFAL does not persist refresh results or own consumer scheduling, cron, locking, retry, backoff, freshness, or migration policy, and it will not select Font Awesome 8 automatically.
+- Preserved the existing public API, shortcode output, stylesheet behavior, editor compatibility, optional v4 compatibility, first-caller singleton contract, and explicit Font Awesome 5 behavior. The BFAL version change updates WordPress stylesheet and script cache keys to `3.0.0-rc.1`.
+- Kept BFAL 2.1.0 as the stable rollback release. Better Font Awesome integration and browser acceptance remain pending and are required before BFAL 3.0.0 stable publication.
+
+To install this release candidate after its tag is published:
+
+```console
+composer require mickey-kay/better-font-awesome-library:3.0.0-rc.1
+```
+
+To roll back to the stable Font Awesome 5 release:
+
+```console
+composer require mickey-kay/better-font-awesome-library:2.1.0 --with-all-dependencies
+```
+
 ## 2.1.0
 
 - Promoted the accepted 2.1.0-rc.2 implementation to stable with validated live Font Awesome Free 5.x metadata and no metadata HTTP on ordinary frontend, admin, editor, REST, or other request paths.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Better Font Awesome Library
 1. [Introduction](https://github.com/MickeyKay/better-font-awesome-library#introduction)
 1. [Features](https://github.com/MickeyKay/better-font-awesome-library#features)
 1. [Installation](https://github.com/MickeyKay/better-font-awesome-library#installation)
-1. [Stable release and rollback](https://github.com/MickeyKay/better-font-awesome-library#stable-release-and-rollback)
-1. [Font Awesome 7 and the next major BFAL release](https://github.com/MickeyKay/better-font-awesome-library#font-awesome-7-and-the-next-major-bfal-release)
+1. [Stable release and prerelease rollback](https://github.com/MickeyKay/better-font-awesome-library#stable-release-and-prerelease-rollback)
+1. [Font Awesome 7 and BFAL 3](https://github.com/MickeyKay/better-font-awesome-library#font-awesome-7-and-bfal-3)
 1. [Changelog](https://github.com/MickeyKay/better-font-awesome-library/blob/master/CHANGELOG.md)
 1. [Usage](https://github.com/MickeyKay/better-font-awesome-library#usage)
 1. [Metadata lifecycle](https://github.com/MickeyKay/better-font-awesome-library#metadata-lifecycle)
@@ -21,7 +21,7 @@ Better Font Awesome Library
 1. [Credits](https://github.com/MickeyKay/better-font-awesome-library#credits)
 
 ## Introduction ##
-The Better Font Awesome Library integrates validated Font Awesome Free metadata and channel-coupled assets into WordPress projects, along with CSS registration, a shortcode, and a TinyMCE icon shortcode generator. Consumers can supply locally resolved metadata and schedule asynchronous refresh work without making normal requests wait on the Font Awesome service. Tagged BFAL 2.x releases use Font Awesome 5.x; the next major BFAL release defaults to Font Awesome 7.x.
+The Better Font Awesome Library integrates validated Font Awesome Free metadata and channel-coupled assets into WordPress projects, along with CSS registration, a shortcode, and a TinyMCE icon shortcode generator. Consumers can supply locally resolved metadata and schedule asynchronous refresh work without making normal requests wait on the Font Awesome service. Tagged BFAL 2.x releases use Font Awesome 5.x; BFAL 3 defaults to Font Awesome 7.x.
 
 ## Features ##
 * Returns validated local metadata immediately from a provider, transient, or bundled fallback.
@@ -45,9 +45,9 @@ cd better-font-awesome-library
 npm run build
 ```
 
-## Stable release and rollback ##
+## Stable release and prerelease rollback ##
 
-After the `2.1.0` tag is published, Composer users can install the exact stable release with:
+BFAL 2.1.0 remains the stable release. Composer users can install it with:
 
 ```
 composer require mickey-kay/better-font-awesome-library:2.1.0
@@ -57,21 +57,19 @@ BFAL 2.1.0 provides validated live Font Awesome Free 5.x metadata with no metada
 
 Normal static Font Awesome stylesheet registration uses anonymous CORS mode on BFAL's exact main and optional v4 shim handles. This preserves Block Editor, Classic Editor, hybrid `wp_editor()` screens, TinyMCE picker, frontend, and v4 compatibility behavior. The runtime version makes WordPress request `?ver=2.1.0` for those handles.
 
-Better Font Awesome PR #52 passed manual release-candidate acceptance at exact BFA commit `3351b5e4c02aaf1694bdb7638cc663f398a5c7a4`. The accepted BFA candidate ZIP SHA-256 is `41e37852f70d1ee5d00cf3260a7da45e950f89755ee184e97a1a50a270333e15`.
-
-To roll back, restore the last stable BFAL release and redeploy the resulting lockfile:
+To roll back from a BFAL 3 prerelease, restore BFAL 2.1.0 and redeploy the resulting lockfile:
 
 ```
-composer require mickey-kay/better-font-awesome-library:2.0.3 --with-all-dependencies
+composer require mickey-kay/better-font-awesome-library:2.1.0 --with-all-dependencies
 ```
 
 BFAL follows versions published from repository tags. The stable release does not change the first-caller singleton ownership contract, introduce a post-construction registration API, or alter metadata transport, validation, caching, fallback, or ownership behavior from the accepted rc.2 implementation.
 
-## Font Awesome 7 and the next major BFAL release ##
+## Font Awesome 7 and BFAL 3 ##
 
-The Font Awesome 7 runtime changes the default Font Awesome major and must not be published as a BFAL 2.x update. Existing tagged BFAL 2.x releases remain the Font Awesome 5-compatible line. A separate reviewed release-preparation change must assign the appropriate next major BFAL version and update its version surfaces and compatibility documentation before publication.
+BFAL 3 changes the default Font Awesome major. Existing tagged BFAL 2.x releases remain the stable Font Awesome 5-compatible line. BFAL 3 release candidates are intended for integration testing, and Better Font Awesome integration and browser acceptance are required before BFAL 3.0.0 stable publication.
 
-The next major BFAL release defaults to the `7.x` release channel when the first caller supplies no `release_channel` argument. Explicit `release_channel => '7.x'` is identical to that default. Consumers that deliberately require the legacy runtime can select `release_channel => '5.x'`. The first caller owns this immutable selection, just like every other initialization argument.
+BFAL 3 defaults to the `7.x` release channel when the first caller supplies no `release_channel` argument. Explicit `release_channel => '7.x'` is identical to that default. Consumers that deliberately require the legacy runtime can select `release_channel => '5.x'`. The first caller owns this immutable selection, just like every other initialization argument.
 
 The 7.x channel validates and loads the packaged Font Awesome Free 7.3.1 baseline immediately. Its CSS and WOFF2 URLs are derived from the BFAL installation URL, so activation needs no HTTP request, cron run, migration, pending state, or setting. Normal frontend, admin, editor, REST, shortcode, picker, and getter paths perform no metadata HTTP.
 
@@ -190,7 +188,7 @@ The following arguments can be used to initialize the library using `Better_Font
 #### $args['release_channel'] ####
 
 (string) Immutable Font Awesome Free major channel selected by the first singleton caller.
-* `7.x` (default for the next major BFAL release)
+* `7.x` (default in BFAL 3)
 * `5.x` - explicit legacy behavior compatible with the BFAL 2.x runtime
 
 The selected 7.x channel follows completely validated 7.x releases only. It will not update across a future Font Awesome major.

--- a/better-font-awesome-library.php
+++ b/better-font-awesome-library.php
@@ -51,7 +51,7 @@ class Better_Font_Awesome_Library {
 	 *
 	 * @var    string
 	 */
-	const VERSION = '2.1.0';
+	const VERSION = '3.0.0-rc.1';
 
 	/**
 	 * Font awesome GraphQL url.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-font-awesome-library",
-  "version": "2.1.0",
+  "version": "3.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-font-awesome-library",
-      "version": "2.1.0",
+      "version": "3.0.0-rc.1",
       "license": "GPL-2.0",
       "devDependencies": {
         "fontawesome-iconpicker": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-font-awesome-library",
   "description": "Better Font Awesome Library",
-  "version": "2.1.0",
+  "version": "3.0.0-rc.1",
   "main": " ",
   "devDependencies": {
     "fontawesome-iconpicker": "3.2.0",

--- a/runtime-assets/package-lock.json
+++ b/runtime-assets/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-font-awesome-library-runtime-assets",
-  "version": "2.1.0",
+  "version": "3.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-font-awesome-library-runtime-assets",
-      "version": "2.1.0",
+      "version": "3.0.0-rc.1",
       "dependencies": {
         "fontawesome-iconpicker": "3.2.0"
       }

--- a/runtime-assets/package.json
+++ b/runtime-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-font-awesome-library-runtime-assets",
-  "version": "2.1.0",
+  "version": "3.0.0-rc.1",
   "private": true,
   "description": "Audit manifest for third-party browser source copied into BFAL release archives.",
   "dependencies": {

--- a/tests/PublicCompatibilityTest.php
+++ b/tests/PublicCompatibilityTest.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/BfalTestCase.php';
 class PublicCompatibilityTest extends BfalTestCase {
 	public function test_public_constants_are_preserved() {
 		$this->assertSame( 'bfa', Better_Font_Awesome_Library::SLUG );
-		$this->assertSame( '2.1.0', Better_Font_Awesome_Library::VERSION );
+		$this->assertSame( '3.0.0-rc.1', Better_Font_Awesome_Library::VERSION );
 		$this->assertSame( 'https://api.fontawesome.com', Better_Font_Awesome_Library::FONT_AWESOME_API_BASE_URL );
 		$this->assertSame( 'https://use.fontawesome.com/releases', Better_Font_Awesome_Library::FONT_AWESOME_CDN_BASE_URL );
 		$this->assertSame( 'inc/fallback-release-data.json', Better_Font_Awesome_Library::FALLBACK_RELEASE_DATA_PATH );
@@ -208,12 +208,21 @@ class PublicCompatibilityTest extends BfalTestCase {
 
 		$this->assertArrayHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_registered_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_registered_styles'] );
-		$this->assertSame( '2.1.0', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome']['version'] );
-		$this->assertSame( '2.1.0', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome-v4-shim']['version'] );
+		$this->assertSame( '3.0.0-rc.1', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome']['version'] );
+		$this->assertSame( '3.0.0-rc.1', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome-v4-shim']['version'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_enqueued_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_enqueued_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_inline_styles'] );
 		$this->assertStringContainsString( '/v5.15.4/webfonts/fa-solid-900.woff2', $GLOBALS['bfa_test_inline_styles']['bfa-font-awesome-v4-shim'] );
+	}
+
+	public function test_admin_asset_cache_keys_use_the_release_version() {
+		$this->get_instance()->enqueue_admin_scripts();
+
+		$this->assertSame( '3.0.0-rc.1', $GLOBALS['bfa_test_enqueued_styles']['bfa-admin']['version'] );
+		$this->assertSame( '3.0.0-rc.1', $GLOBALS['bfa_test_enqueued_styles']['fontawesome-iconpicker']['version'] );
+		$this->assertSame( '3.0.0-rc.1', $GLOBALS['bfa_test_enqueued_scripts']['bfa-admin']['version'] );
+		$this->assertSame( '3.0.0-rc.1', $GLOBALS['bfa_test_enqueued_scripts']['fontawesome-iconpicker']['version'] );
 	}
 
 	public function test_documented_initialization_and_notice_filters_remain_active() {


### PR DESCRIPTION
# Summary

- Prepare BFAL `3.0.0-rc.1` as the next-major release candidate for integration testing.
- Update every established release identity surface and add explicit stylesheet and script cache-key coverage.
- Document the Font Awesome 7 default, explicit Font Awesome 5 compatibility channel, first-caller ownership, zero-HTTP normal request behavior, consumer-owned orchestration, Font Awesome 8 boundary, and stable rollback.
- Make no runtime behavior change beyond the BFAL version identity.

# Provenance and tree identity

- Required `origin/master`: `ca56e3e0e612524ca6b0719db31a3587ef0e3a51`
- Reviewed PR #47 head: `c57c6a448e21b721fa491784235ba9eb947fd2ea`
- Complete tree for both commits: `50f733c905e7840faf68497ae5225f5532b4e5a1`
- `git diff --quiet origin/master^{tree} c57c6a448e21b721fa491784235ba9eb947fd2ea^{tree}`: exit 0
- Release-preparation head: `513f59c109a9cf8c490f2812622be2f3e542f8b8`

# Changed files and version surfaces

- `better-font-awesome-library.php`: `Better_Font_Awesome_Library::VERSION`
- `package.json` and its lockfile root records
- `runtime-assets/package.json` and its lockfile root records
- `tests/PublicCompatibilityTest.php`: constant plus stylesheet and script cache-key assertions
- `CHANGELOG.md`: exact candidate behavior, Composer prerelease installation, rollback, and remaining stable gates
- `README.md`: evergreen BFAL 3 compatibility and BFAL 2.1.0 rollback guidance

`composer.json` remains versionless and has no branch alias.

# Runtime diff proof

The complete runtime implementation diff across `better-font-awesome-library.php`, `inc/`, `css/`, `js/`, and `lib/` is:

```diff
- const VERSION = '2.1.0';
+ const VERSION = '3.0.0-rc.1';
```

No channel selection, fallback data, asset routing, validator, adapter, refresher, request budget, endpoint contract, singleton ownership, public method, or compatibility style implementation changed. The Font Awesome 7.3.1 fallback was not regenerated or modified.

# Local validation

- `composer validate --strict`: pass
- `composer audit`: pass, no security advisories
- PHPUnit on local PHP 8.5: 170 tests, 4,945 assertions
- PHPCS: 6 of 6 pass
- PHPStan: no errors
- PHPUnit on PHP 7.4 using the preinstalled read-only container image: 170 tests, 4,945 assertions
- `npm run build`: pass, tracked browser assets remain byte-identical
- `npm run audit:runtime-assets`: pass, `fontawesome-iconpicker` 3.2.0 coverage verified, zero shipped runtime vulnerabilities
- `npm run verify:font-awesome-7-fallback`: pass, 13 files verified for `@fortawesome/fontawesome-free@7.3.1`
- `git diff --check`: pass

The root `npm ci` audit still reports the existing three high-severity development-only findings. The separately pinned shipped runtime dependency audit reports zero vulnerabilities, and this release change neither worsens nor ships the development-only findings.

Both hosted push and pull-request matrices pass on the exact release-preparation head: PHP 7.4, 8.0, 8.1, 8.2, 8.3, and 8.4, plus quality and packaging. GitGuardian also passes.

# Provisional production artifact

- Source commit: `513f59c109a9cf8c490f2812622be2f3e542f8b8`
- Archive: `better-font-awesome-library-3.0.0-rc.1.zip`
- Root: `better-font-awesome-library-3.0.0-rc.1/`
- Production inventory: 35 files, derived from the archive
- Size: 459,603 bytes
- SHA-256: `9fe44eb9d11a3c6dbcc0aceb9eeefa1c0024e17debde11c2933ca83fa197f9bd`
- Determinism: two clean `git archive` builds from the same commit compare byte-identically
- ZIP integrity: pass

<details>
<summary>Exact production inventory</summary>

```text
CHANGELOG.md
LICENSE
README.md
THIRD-PARTY-NOTICES.md
better-font-awesome-library.php
composer.json
css/admin-styles.css
css/admin-styles.min.css
inc/class-bfa-release-channel.php
inc/class-bfa-release-data-v2-adapter.php
inc/class-bfa-release-data-v2-refresher.php
inc/class-bfa-release-data-v2-validator.php
inc/class-bfa-release-data-validator.php
inc/fallback-release-data.json
inc/fallback-release-data.sha256
inc/font-awesome-7-fallback/ATTRIBUTION.md
inc/font-awesome-7-fallback/LICENSE.txt
inc/font-awesome-7-fallback/css/all.min.css
inc/font-awesome-7-fallback/css/v4-font-face.min.css
inc/font-awesome-7-fallback/css/v4-shims.min.css
inc/font-awesome-7-fallback/css/v5-font-face.min.css
inc/font-awesome-7-fallback/metadata.json
inc/font-awesome-7-fallback/provenance.json
inc/font-awesome-7-fallback/provenance.sha256
inc/font-awesome-7-fallback/webfonts/fa-brands-400.woff2
inc/font-awesome-7-fallback/webfonts/fa-regular-400.woff2
inc/font-awesome-7-fallback/webfonts/fa-solid-900.woff2
inc/font-awesome-7-fallback/webfonts/fa-v4compatibility.woff2
js/admin.js
js/admin.min.js
lib/fontawesome-iconpicker/LICENSE
lib/fontawesome-iconpicker/dist/css/fontawesome-iconpicker.css
lib/fontawesome-iconpicker/dist/css/fontawesome-iconpicker.min.css
lib/fontawesome-iconpicker/dist/js/fontawesome-iconpicker.js
lib/fontawesome-iconpicker/dist/js/fontawesome-iconpicker.min.js
```

</details>

Required PHP, CSS, JavaScript, WOFF2, metadata, licenses, notices, checksums, attribution, and provenance are present. Tests, scripts, agent files, release tooling, development configuration and locks, `node_modules`, `vendor`, and local artifacts are absent.

# Publication and remaining gates

- No local or remote `3.0.0-rc.1` or `v3.0.0-rc.1` tag exists.
- No GitHub release exists for `3.0.0-rc.1`.
- Packagist reports zero `3.0.0-rc.1` versions.
- No tag, GitHub release, Packagist version, merge, or other publication was created.
- BFAL 2.1.0 remains the stable rollback release.
- Better Font Awesome integration and browser acceptance remain pending and are required before BFAL 3.0.0 stable publication.
