### PR TITLE
Prepare BFAL 3.0.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 3.0.0
+
+- Promoted the accepted 3.0.0-rc.1 implementation to stable without production behavior changes beyond the BFAL version identity and resulting asset cache keys.
+- Made Font Awesome 7 the stable default while preserving explicit `release_channel => '5.x'` behavior, the first-caller singleton contract, existing public APIs, and channel-specific asset and metadata precedence.
+- Preserved the no-HTTP ordinary-request contract. Metadata transport remains limited to explicit asynchronous refresh work, and BFAL continues not to own WordPress persistence, scheduling, locking, retry, freshness, or migration policy.
+- Kept the packaged Font Awesome Free 7.3.1 fallback unchanged from the accepted release candidate.
+- Updated BFAL stylesheet and script cache keys from `3.0.0-rc.1` to `3.0.0`.
+
+To install the stable release after its tag is published:
+
+```console
+composer require mickey-kay/better-font-awesome-library:3.0.0
+```
+
+To roll back to the stable Font Awesome 5 release:
+
+```console
+composer require mickey-kay/better-font-awesome-library:2.1.0 --with-all-dependencies
+```
+
 ## 3.0.0-rc.1
 
 - Prepared the BFAL 3 next-major release candidate for integration testing. BFAL now defaults to Font Awesome 7 Free when the first caller omits `release_channel`; no channel argument is required for the default.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Better Font Awesome Library
 1. [Introduction](https://github.com/MickeyKay/better-font-awesome-library#introduction)
 1. [Features](https://github.com/MickeyKay/better-font-awesome-library#features)
 1. [Installation](https://github.com/MickeyKay/better-font-awesome-library#installation)
-1. [Stable release and prerelease rollback](https://github.com/MickeyKay/better-font-awesome-library#stable-release-and-prerelease-rollback)
+1. [Stable release and rollback](https://github.com/MickeyKay/better-font-awesome-library#stable-release-and-rollback)
 1. [Font Awesome 7 and BFAL 3](https://github.com/MickeyKay/better-font-awesome-library#font-awesome-7-and-bfal-3)
 1. [Changelog](https://github.com/MickeyKay/better-font-awesome-library/blob/master/CHANGELOG.md)
 1. [Usage](https://github.com/MickeyKay/better-font-awesome-library#usage)
@@ -35,7 +35,7 @@ The Better Font Awesome Library integrates validated Font Awesome Free metadata 
 ## Installation ##
 The Better Font Awesome Library should ideally be installed via Composer:
 ```
-composer require mickey-kay/better-font-awesome-library:2.1.0
+composer require mickey-kay/better-font-awesome-library:3.0.0
 ```
 
 Alternately, you can install the library manually, which can be useful for development and/or custom builds:
@@ -45,29 +45,29 @@ cd better-font-awesome-library
 npm run build
 ```
 
-## Stable release and prerelease rollback ##
+## Stable release and rollback ##
 
-BFAL 2.1.0 remains the stable release. Composer users can install it with:
+BFAL 3.0.0 is the stable release. Composer users can install it with:
 
 ```
-composer require mickey-kay/better-font-awesome-library:2.1.0
+composer require mickey-kay/better-font-awesome-library:3.0.0
 ```
 
-BFAL 2.1.0 provides validated live Font Awesome Free 5.x metadata with no metadata HTTP on ordinary requests. It supports consumer-controlled asynchronous refresh orchestration, durable last-known-good data in the Better Font Awesome consumer, and a checksummed bundled fallback. The accepted BFA integration supplies WordPress-owned scheduling, retry, locking, migration, and multisite behavior.
+BFAL 3.0.0 defaults to Font Awesome 7 and preserves explicit Font Awesome 5 selection. Ordinary requests perform no metadata or candidate-validation HTTP. BFAL provides validated local metadata, packaged fallback assets, and explicit asynchronous refresh operations while consumers continue to own WordPress persistence, scheduling, locking, retry, freshness, and migration policy.
 
-Normal static Font Awesome stylesheet registration uses anonymous CORS mode on BFAL's exact main and optional v4 shim handles. This preserves Block Editor, Classic Editor, hybrid `wp_editor()` screens, TinyMCE picker, frontend, and v4 compatibility behavior. The runtime version makes WordPress request `?ver=2.1.0` for those handles.
+The stable release promotes the accepted 3.0.0-rc.1 runtime without behavior changes beyond the version identity. The packaged Font Awesome Free 7.3.1 fallback is unchanged, and WordPress now uses `?ver=3.0.0` for BFAL stylesheet and script cache keys.
 
-To roll back from a BFAL 3 prerelease, restore BFAL 2.1.0 and redeploy the resulting lockfile:
+To roll back to the Font Awesome 5 stable line, restore BFAL 2.1.0 and redeploy the resulting lockfile:
 
 ```
 composer require mickey-kay/better-font-awesome-library:2.1.0 --with-all-dependencies
 ```
 
-BFAL follows versions published from repository tags. The stable release does not change the first-caller singleton ownership contract, introduce a post-construction registration API, or alter metadata transport, validation, caching, fallback, or ownership behavior from the accepted rc.2 implementation.
+BFAL follows versions published from repository tags. BFAL 3.0.0 does not change the first-caller singleton ownership contract, introduce a post-construction registration API, or alter channels, metadata transport, validation, caching, fallback, refresh, routing, public APIs, precedence, or ownership behavior from the accepted 3.0.0-rc.1 implementation.
 
 ## Font Awesome 7 and BFAL 3 ##
 
-BFAL 3 changes the default Font Awesome major. Existing tagged BFAL 2.x releases remain the stable Font Awesome 5-compatible line. BFAL 3 release candidates are intended for integration testing, and Better Font Awesome integration and browser acceptance are required before BFAL 3.0.0 stable publication.
+BFAL 3.0.0 changes the default Font Awesome major. Existing tagged BFAL 2.x releases remain the Font Awesome 5-compatible stable line for consumers that cannot yet adopt the new default.
 
 BFAL 3 defaults to the `7.x` release channel when the first caller supplies no `release_channel` argument. Explicit `release_channel => '7.x'` is identical to that default. Consumers that deliberately require the legacy runtime can select `release_channel => '5.x'`. The first caller owns this immutable selection, just like every other initialization argument.
 

--- a/better-font-awesome-library.php
+++ b/better-font-awesome-library.php
@@ -51,7 +51,7 @@ class Better_Font_Awesome_Library {
 	 *
 	 * @var    string
 	 */
-	const VERSION = '3.0.0-rc.1';
+	const VERSION = '3.0.0';
 
 	/**
 	 * Font awesome GraphQL url.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-font-awesome-library",
-  "version": "3.0.0-rc.1",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-font-awesome-library",
-      "version": "3.0.0-rc.1",
+      "version": "3.0.0",
       "license": "GPL-2.0",
       "devDependencies": {
         "fontawesome-iconpicker": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-font-awesome-library",
   "description": "Better Font Awesome Library",
-  "version": "3.0.0-rc.1",
+  "version": "3.0.0",
   "main": " ",
   "devDependencies": {
     "fontawesome-iconpicker": "3.2.0",

--- a/runtime-assets/package-lock.json
+++ b/runtime-assets/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-font-awesome-library-runtime-assets",
-  "version": "3.0.0-rc.1",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-font-awesome-library-runtime-assets",
-      "version": "3.0.0-rc.1",
+      "version": "3.0.0",
       "dependencies": {
         "fontawesome-iconpicker": "3.2.0"
       }

--- a/runtime-assets/package.json
+++ b/runtime-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-font-awesome-library-runtime-assets",
-  "version": "3.0.0-rc.1",
+  "version": "3.0.0",
   "private": true,
   "description": "Audit manifest for third-party browser source copied into BFAL release archives.",
   "dependencies": {

--- a/tests/PublicCompatibilityTest.php
+++ b/tests/PublicCompatibilityTest.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/BfalTestCase.php';
 class PublicCompatibilityTest extends BfalTestCase {
 	public function test_public_constants_are_preserved() {
 		$this->assertSame( 'bfa', Better_Font_Awesome_Library::SLUG );
-		$this->assertSame( '3.0.0-rc.1', Better_Font_Awesome_Library::VERSION );
+		$this->assertSame( '3.0.0', Better_Font_Awesome_Library::VERSION );
 		$this->assertSame( 'https://api.fontawesome.com', Better_Font_Awesome_Library::FONT_AWESOME_API_BASE_URL );
 		$this->assertSame( 'https://use.fontawesome.com/releases', Better_Font_Awesome_Library::FONT_AWESOME_CDN_BASE_URL );
 		$this->assertSame( 'inc/fallback-release-data.json', Better_Font_Awesome_Library::FALLBACK_RELEASE_DATA_PATH );
@@ -208,8 +208,8 @@ class PublicCompatibilityTest extends BfalTestCase {
 
 		$this->assertArrayHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_registered_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_registered_styles'] );
-		$this->assertSame( '3.0.0-rc.1', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome']['version'] );
-		$this->assertSame( '3.0.0-rc.1', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome-v4-shim']['version'] );
+		$this->assertSame( '3.0.0', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome']['version'] );
+		$this->assertSame( '3.0.0', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome-v4-shim']['version'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_enqueued_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_enqueued_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_inline_styles'] );
@@ -219,10 +219,10 @@ class PublicCompatibilityTest extends BfalTestCase {
 	public function test_admin_asset_cache_keys_use_the_release_version() {
 		$this->get_instance()->enqueue_admin_scripts();
 
-		$this->assertSame( '3.0.0-rc.1', $GLOBALS['bfa_test_enqueued_styles']['bfa-admin']['version'] );
-		$this->assertSame( '3.0.0-rc.1', $GLOBALS['bfa_test_enqueued_styles']['fontawesome-iconpicker']['version'] );
-		$this->assertSame( '3.0.0-rc.1', $GLOBALS['bfa_test_enqueued_scripts']['bfa-admin']['version'] );
-		$this->assertSame( '3.0.0-rc.1', $GLOBALS['bfa_test_enqueued_scripts']['fontawesome-iconpicker']['version'] );
+		$this->assertSame( '3.0.0', $GLOBALS['bfa_test_enqueued_styles']['bfa-admin']['version'] );
+		$this->assertSame( '3.0.0', $GLOBALS['bfa_test_enqueued_styles']['fontawesome-iconpicker']['version'] );
+		$this->assertSame( '3.0.0', $GLOBALS['bfa_test_enqueued_scripts']['bfa-admin']['version'] );
+		$this->assertSame( '3.0.0', $GLOBALS['bfa_test_enqueued_scripts']['fontawesome-iconpicker']['version'] );
 	}
 
 	public function test_documented_initialization_and_notice_filters_remain_active() {


### PR DESCRIPTION
## Summary

Promote BFAL 3.0.0-rc.1 to 3.0.0 stable. The only production PHP behavior change is `Better_Font_Awesome_Library::VERSION` from `3.0.0-rc.1` to `3.0.0`, which updates BFAL stylesheet and script cache keys.

This keeps Font Awesome 7 as the default, preserves explicit 5.x selection, performs no metadata or candidate-validation HTTP on ordinary requests, and leaves WordPress persistence and scheduling to consumers. `composer.json` remains versionless.

## RC evidence

- BFAL 3.0.0-rc.1 is exact commit `1ec60a55c312ffed689f9fc1c3046b3982daee61`.
- BFA PR #57 integrated that exact RC and merged as BFA commit `ae5c758e75cbe4784cd7ba732646aa999b4ecd04`.
- That integration passed independent review, exhaustive automated coverage, packaged-plugin testing, and manual upgrade QA.
- Browser QA was not repeated because the stable promotion changes only BFAL version identity and resulting cache keys.

## Stable-candidate evidence

Candidate commit: `b6e27dd9ba30303abf044b4d9a4db8630d8af03e`

- PHPUnit: 170 tests, 4,945 assertions.
- PHPCS: passed.
- PHPStan: passed with no errors.
- Composer strict validation and security audit: passed.
- Reproducible asset build: passed with no tracked output drift.
- Font Awesome 7 fallback verification: 13 files for `@fortawesome/fontawesome-free@7.3.1`.
- Runtime asset audit: `fontawesome-iconpicker` 3.2.0 coverage verified, 0 production vulnerabilities.
- Hosted CI: PHP 7.4, 8.0, 8.1, 8.2, 8.3, and 8.4 passed. Quality and deterministic packaging passed.
- RC and stable fallback tree object: `0d8c378d43baaa5be4f13a4038ac6e5f9aec28c8`.
- Focused BFA compatibility at `ae5c758e75cbe4784cd7ba732646aa999b4ecd04`: 10 tests, 88 assertions. Verified dependency identity, initialization, default FA7, explicit FA5, schema records, no ordinary-path HTTP, persistence handoff, and stable cache keys for four styles and two scripts.

Two archives built independently from the candidate commit are byte-identical:

- Inventory: 35 production files under the single `better-font-awesome-library-3.0.0/` root.
- Size: 459,228 bytes each.
- SHA-256: `f7a32d02948ef330a79d572962cdb553302728c045bcf138381db687d28e8ec7`.
- Excluded: tests, agent files, repository configuration, development locks and manifests, build sources and release tooling, `node_modules`, and `vendor`.
- All 13 archived Font Awesome 7.3.1 fallback files match the RC source byte-for-byte.

## Remaining publication gates

- Complete review and merge this PR.
- Require the hosted PHP compatibility and production-package matrix to pass on the final merged commit.
- After merge, create and verify the `3.0.0` tag and two deterministic archives from the merged commit.
- Only after those checks, push the tag, create the GitHub release with the verified archive and checksum, and confirm Packagist discovery.

Do not merge, tag, publish a release, or update Packagist as part of this PR.
