### PR TITLE
Prepare BFAL 3.0.1 corrective release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.0.1
+
+- Treat an exact empty array from `release_data_provider` as a normal indication that no local candidate is available, without recording a provider validation error.
+- Continue resolving the established transient or bundled fallback after that sentinel and requesting asynchronous refresh when fallback is selected.
+- Preserve validation and diagnostics for every other provider result, including malformed data, channel mismatches, and `WP_Error` values.
+- Correct the third-party notice to identify Font Awesome Free 7.3.1 as the active default fallback and Font Awesome Free 5.14.0 as the fallback for explicit 5.x consumers.
+- Update BFAL stylesheet and script cache keys to `3.0.1` without changing editor behavior or packaged runtime assets.
+
 ## 3.0.0
 
 - Promoted the accepted 3.0.0-rc.1 implementation to stable without production behavior changes beyond the BFAL version identity and resulting asset cache keys.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The Better Font Awesome Library integrates validated Font Awesome Free metadata 
 ## Installation ##
 The Better Font Awesome Library should ideally be installed via Composer:
 ```
-composer require mickey-kay/better-font-awesome-library:3.0.0
+composer require mickey-kay/better-font-awesome-library:3.0.1
 ```
 
 Alternately, you can install the library manually, which can be useful for development and/or custom builds:
@@ -47,15 +47,15 @@ npm run build
 
 ## Stable release and rollback ##
 
-BFAL 3.0.0 is the stable release. Composer users can install it with:
+BFAL 3.0.1 is the stable release. Composer users can install it with:
 
 ```
-composer require mickey-kay/better-font-awesome-library:3.0.0
+composer require mickey-kay/better-font-awesome-library:3.0.1
 ```
 
-BFAL 3.0.0 defaults to Font Awesome 7 and preserves explicit Font Awesome 5 selection. Ordinary requests perform no metadata or candidate-validation HTTP. BFAL provides validated local metadata, packaged fallback assets, and explicit asynchronous refresh operations while consumers continue to own WordPress persistence, scheduling, locking, retry, freshness, and migration policy.
+BFAL 3.0.1 defaults to Font Awesome 7 and preserves explicit Font Awesome 5 selection. Ordinary requests perform no metadata or candidate-validation HTTP. BFAL provides validated local metadata, packaged fallback assets, and explicit asynchronous refresh operations while consumers continue to own WordPress persistence, scheduling, locking, retry, freshness, and migration policy.
 
-The stable release promotes the accepted 3.0.0-rc.1 runtime without behavior changes beyond the version identity. The packaged Font Awesome Free 7.3.1 fallback is unchanged, and WordPress now uses `?ver=3.0.0` for BFAL stylesheet and script cache keys.
+The corrective release treats an exact empty provider array as no locally available candidate, then continues to the established transient or bundled fallback. The packaged Font Awesome Free 7.3.1 fallback is unchanged, and WordPress uses `?ver=3.0.1` for BFAL stylesheet and script cache keys.
 
 To roll back to the Font Awesome 5 stable line, restore BFAL 2.1.0 and redeploy the resulting lockfile:
 
@@ -63,7 +63,7 @@ To roll back to the Font Awesome 5 stable line, restore BFAL 2.1.0 and redeploy 
 composer require mickey-kay/better-font-awesome-library:2.1.0 --with-all-dependencies
 ```
 
-BFAL follows versions published from repository tags. BFAL 3.0.0 does not change the first-caller singleton ownership contract, introduce a post-construction registration API, or alter channels, metadata transport, validation, caching, fallback, refresh, routing, public APIs, precedence, or ownership behavior from the accepted 3.0.0-rc.1 implementation.
+BFAL follows versions published from repository tags. BFAL 3.0.1 preserves the first-caller singleton ownership contract, channels, metadata transport, validation, caching, fallback, refresh, routing, public APIs, precedence, and ownership behavior established in 3.0.0.
 
 ## Font Awesome 7 and BFAL 3 ##
 
@@ -132,7 +132,7 @@ Normal frontend, admin, editor, REST, and cron-triggering requests never call th
 
 When BFAL reaches the fallback, it invokes `release_data_refresh_callback` once if configured. Otherwise it fires `bfa_release_data_refresh_requested` with the supported channel and library instance. The handler must only schedule work and return promptly. Scheduling, locking, durable last-known-good persistence, retry backoff, jitter, and freshness policy belong to the consumer.
 
-A provider may return a release array or a declared BFAL release record. Declared records must use the exact supported `schema_version`, `channel`, and `edition`, an allowed `source`, and a fully valid nested release. BFAL rejects mismatches rather than discarding or normalizing them.
+A provider may return a release array or a declared BFAL release record. An exact empty array means that the provider has no locally available candidate yet. Declared records must use the exact supported `schema_version`, `channel`, and `edition`, an allowed `source`, and a fully valid nested release. BFAL rejects mismatches rather than discarding or normalizing them.
 
 An asynchronous worker can call `refresh_release_data()`. For explicit `5.x`, the established operation retains its existing validated transient behavior and release-array return value. For `7.x`, one bounded attempt returns a complete validated schema-2 record or a sanitized `WP_Error` and performs no BFAL persistence. Both paths require TLS, reject redirects and unsafe URLs, and leave the prior validated data untouched on failure.
 
@@ -179,7 +179,7 @@ The following arguments can be used to initialize the library using `Better_Font
 
 #### $args['release_data_provider'] ####
 
-(callable|null) Optional callable that returns an already-resolved release array or BFAL release record. Providers used by normal getters must not perform remote I/O.
+(callable|null) Optional callable that returns an already-resolved release array or BFAL release record. An exact empty array indicates that no local candidate is currently available. Providers used by normal getters must not perform remote I/O.
 
 #### $args['release_data_refresh_callback'] ####
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -30,13 +30,13 @@ licenses by asset category:
 
 License details: https://fontawesome.com/license/free
 
-For the active Font Awesome 5 channel, BFAL bundles metadata only. Browser CSS
+For the explicit Font Awesome 5 channel, BFAL bundles metadata only. Browser CSS
 and webfonts are fetched from the Font Awesome Free v5 CDN when consumers
 enable those existing BFAL features.
 
-## Font Awesome Free 7.3.1 inactive fallback
+## Font Awesome Free 7.3.1 default fallback
 
-BFAL also packages an inactive cold-start and recovery baseline generated from
+BFAL packages the active default cold-start and recovery baseline generated from
 the exact official npm release `@fortawesome/fontawesome-free@7.3.1`. Its
 reduced Free metadata, four required minified stylesheets, and four WOFF2
 webfonts are under `inc/font-awesome-7-fallback`.
@@ -50,6 +50,6 @@ webfonts are under `inc/font-awesome-7-fallback`.
 - Bundled license: `inc/font-awesome-7-fallback/LICENSE.txt`
 - Reproducible provenance: `inc/font-awesome-7-fallback/provenance.json`
 
-This baseline is not selected by the production runtime in this release. The
-existing Font Awesome 5 fallback remains active and retains its established
-lowest-precedence behavior.
+This baseline is selected by the default Font Awesome 7 production runtime and
+retains its established lowest-precedence behavior. The Font Awesome 5 metadata
+fallback remains available to explicit 5.x consumers.

--- a/better-font-awesome-library.php
+++ b/better-font-awesome-library.php
@@ -51,7 +51,7 @@ class Better_Font_Awesome_Library {
 	 *
 	 * @var    string
 	 */
-	const VERSION = '3.0.0';
+	const VERSION = '3.0.1';
 
 	/**
 	 * Font awesome GraphQL url.
@@ -644,6 +644,10 @@ class Better_Font_Awesome_Library {
 		}
 
 		$provided = call_user_func( $provider );
+		if ( array() === $provided ) {
+			return array();
+		}
+
 		if ( is_wp_error( $provided ) ) {
 			$this->set_error( 'provider', 'bfa_provider_error', 'The release data provider could not supply Font Awesome metadata.' );
 			return array();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-font-awesome-library",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-font-awesome-library",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "GPL-2.0",
       "devDependencies": {
         "fontawesome-iconpicker": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-font-awesome-library",
   "description": "Better Font Awesome Library",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": " ",
   "devDependencies": {
     "fontawesome-iconpicker": "3.2.0",

--- a/runtime-assets/package-lock.json
+++ b/runtime-assets/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-font-awesome-library-runtime-assets",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-font-awesome-library-runtime-assets",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dependencies": {
         "fontawesome-iconpicker": "3.2.0"
       }

--- a/runtime-assets/package.json
+++ b/runtime-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-font-awesome-library-runtime-assets",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "description": "Audit manifest for third-party browser source copied into BFAL release archives.",
   "dependencies": {

--- a/tests/FontAwesome7RuntimeTest.php
+++ b/tests/FontAwesome7RuntimeTest.php
@@ -34,6 +34,106 @@ class FontAwesome7RuntimeTest extends BfalTestCase {
 		$this->assertSame( array(), $GLOBALS['bfa_test_transient_writes'] );
 	}
 
+	public function test_empty_provider_result_uses_packaged_fallback_without_a_diagnostic() {
+		$provider_calls   = 0;
+		$refresh_requests = array();
+		$library          = Better_Font_Awesome_Library::get_instance(
+			array(
+				'release_data_provider'         => function () use ( &$provider_calls ) {
+					++$provider_calls;
+					return array();
+				},
+				'release_data_refresh_callback' => function ( $channel, $instance ) use ( &$refresh_requests ) {
+					$refresh_requests[] = array( $channel, $instance );
+				},
+			)
+		);
+
+		$this->assertSame( '7.3.1', $library->get_version() );
+		$this->assertSame( 'fallback', $library->get_release_record()['source'] );
+		$this->assertStringContainsString( '/font-awesome-7-fallback/', $library->get_stylesheet_url() );
+		$this->assertSame( '', $library->get_error( 'provider' ) );
+		$this->assertSame( 1, $provider_calls );
+		$this->assertCount( 1, $refresh_requests );
+		$this->assertSame( '7.x', $refresh_requests[0][0] );
+		$this->assertSame( $library, $refresh_requests[0][1] );
+		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
+
+		$library->get_icons();
+		$library->get_release_assets();
+		$library->request_release_data_refresh();
+
+		$this->assertCount( 1, $refresh_requests );
+		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
+	}
+
+	public function test_malformed_nonempty_provider_result_keeps_the_validation_diagnostic() {
+		$refresh_requests = 0;
+		$library = Better_Font_Awesome_Library::get_instance(
+			array(
+				'release_data_provider'         => function () {
+					return array( 'version' => 'not-valid' );
+				},
+				'release_data_refresh_callback' => function () use ( &$refresh_requests ) {
+					++$refresh_requests;
+				},
+			)
+		);
+
+		$this->assertSame( '7.3.1', $library->get_version() );
+		$this->assertSame( 'bfa_v2_version_invalid', $library->get_error( 'provider' )->get_error_code() );
+		$this->assertSame( 1, $refresh_requests );
+		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
+	}
+
+	/**
+	 * @dataProvider unavailable_or_failed_provider_result_provider
+	 */
+	public function test_other_unavailable_or_failed_provider_results_keep_their_diagnostics( $provided, $expected_code ) {
+		$library = Better_Font_Awesome_Library::get_instance(
+			array(
+				'release_data_provider' => function () use ( $provided ) {
+					return $provided;
+				},
+			)
+		);
+
+		$this->assertSame( '7.3.1', $library->get_version() );
+		$this->assertSame( $expected_code, $library->get_error( 'provider' )->get_error_code() );
+		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
+	}
+
+	public function unavailable_or_failed_provider_result_provider() {
+		return array(
+			'null'     => array( null, 'bfa_v2_release_invalid' ),
+			'false'    => array( false, 'bfa_v2_release_invalid' ),
+			'WP_Error' => array( new WP_Error( 'provider_unavailable', 'Provider unavailable.' ), 'bfa_provider_error' ),
+		);
+	}
+
+	public function test_provider_accepts_a_valid_font_awesome_seven_release_array() {
+		$record  = Better_Font_Awesome_Release_Data_V2_Validator::parse_record_json(
+			file_get_contents( dirname( __DIR__ ) . '/inc/font-awesome-7-fallback/metadata.json' )
+		)['record'];
+		$refresh_calls = 0;
+		$library       = Better_Font_Awesome_Library::get_instance(
+			array(
+				'release_data_provider'         => function () use ( $record ) {
+					return $record['release'];
+				},
+				'release_data_refresh_callback' => function () use ( &$refresh_calls ) {
+					++$refresh_calls;
+				},
+			)
+		);
+
+		$this->assertSame( '7.3.1', $library->get_version() );
+		$this->assertSame( 'provider', $library->get_release_record()['source'] );
+		$this->assertSame( 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.3.1/css/all.min.css', $library->get_stylesheet_url() );
+		$this->assertSame( 0, $refresh_calls );
+		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
+	}
+
 	public function test_first_caller_channel_is_immutable_across_later_callers_and_loads() {
 		$filter_calls = 0;
 		add_filter(

--- a/tests/PublicCompatibilityTest.php
+++ b/tests/PublicCompatibilityTest.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/BfalTestCase.php';
 class PublicCompatibilityTest extends BfalTestCase {
 	public function test_public_constants_are_preserved() {
 		$this->assertSame( 'bfa', Better_Font_Awesome_Library::SLUG );
-		$this->assertSame( '3.0.0', Better_Font_Awesome_Library::VERSION );
+		$this->assertSame( '3.0.1', Better_Font_Awesome_Library::VERSION );
 		$this->assertSame( 'https://api.fontawesome.com', Better_Font_Awesome_Library::FONT_AWESOME_API_BASE_URL );
 		$this->assertSame( 'https://use.fontawesome.com/releases', Better_Font_Awesome_Library::FONT_AWESOME_CDN_BASE_URL );
 		$this->assertSame( 'inc/fallback-release-data.json', Better_Font_Awesome_Library::FALLBACK_RELEASE_DATA_PATH );
@@ -208,8 +208,8 @@ class PublicCompatibilityTest extends BfalTestCase {
 
 		$this->assertArrayHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_registered_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_registered_styles'] );
-		$this->assertSame( '3.0.0', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome']['version'] );
-		$this->assertSame( '3.0.0', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome-v4-shim']['version'] );
+		$this->assertSame( '3.0.1', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome']['version'] );
+		$this->assertSame( '3.0.1', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome-v4-shim']['version'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_enqueued_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_enqueued_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_inline_styles'] );
@@ -219,10 +219,10 @@ class PublicCompatibilityTest extends BfalTestCase {
 	public function test_admin_asset_cache_keys_use_the_release_version() {
 		$this->get_instance()->enqueue_admin_scripts();
 
-		$this->assertSame( '3.0.0', $GLOBALS['bfa_test_enqueued_styles']['bfa-admin']['version'] );
-		$this->assertSame( '3.0.0', $GLOBALS['bfa_test_enqueued_styles']['fontawesome-iconpicker']['version'] );
-		$this->assertSame( '3.0.0', $GLOBALS['bfa_test_enqueued_scripts']['bfa-admin']['version'] );
-		$this->assertSame( '3.0.0', $GLOBALS['bfa_test_enqueued_scripts']['fontawesome-iconpicker']['version'] );
+		$this->assertSame( '3.0.1', $GLOBALS['bfa_test_enqueued_styles']['bfa-admin']['version'] );
+		$this->assertSame( '3.0.1', $GLOBALS['bfa_test_enqueued_styles']['fontawesome-iconpicker']['version'] );
+		$this->assertSame( '3.0.1', $GLOBALS['bfa_test_enqueued_scripts']['bfa-admin']['version'] );
+		$this->assertSame( '3.0.1', $GLOBALS['bfa_test_enqueued_scripts']['fontawesome-iconpicker']['version'] );
 	}
 
 	public function test_documented_initialization_and_notice_filters_remain_active() {

--- a/tests/ReleaseDataRuntimeTest.php
+++ b/tests/ReleaseDataRuntimeTest.php
@@ -31,6 +31,26 @@ class ReleaseDataRuntimeTest extends BfalTestCase {
 		$this->assertSame( 'fallback', $library->get_release_record()['source'] );
 	}
 
+	public function test_empty_provider_preserves_explicit_five_fallback_behavior() {
+		$refresh_calls = 0;
+		$library       = Better_Font_Awesome_Library::get_instance(
+			array(
+				'release_data_provider'         => function () {
+					return array();
+				},
+				'release_data_refresh_callback' => function () use ( &$refresh_calls ) {
+					++$refresh_calls;
+				},
+			)
+		);
+
+		$this->assertSame( '5.14.0', $library->get_version() );
+		$this->assertSame( 'fallback', $library->get_release_record()['source'] );
+		$this->assertSame( '', $library->get_error( 'provider' ) );
+		$this->assertSame( 1, $refresh_calls );
+		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
+	}
+
 	public function test_normal_request_entrypoints_never_perform_transport() {
 		$library = Better_Font_Awesome_Library::get_instance();
 


### PR DESCRIPTION
## Summary

- treat only an exact empty array from `release_data_provider` as the normal no-local-candidate sentinel before validation
- preserve transient and bundled fallback resolution, one asynchronous refresh request, zero-HTTP ordinary getters, and all other provider validation behavior
- correct Font Awesome 7.3.1 and Font Awesome 5 fallback descriptions in third-party notices
- update established BFAL version surfaces to 3.0.1 while keeping `composer.json` versionless

## Verification

- focused runtime tests: 22 tests, 141 assertions
- complete PHPUnit suite: 177 tests, 4,979 assertions
- PHPCS: pass
- PHPStan: pass
- `composer validate --strict`: pass
- `composer audit`: no advisories
- final `npm run build`: reproducible with no tracked drift
- shipped runtime asset audit: 0 vulnerabilities
- Font Awesome 7 fallback verification: 13 files verified
- `git diff --check`: pass
- fallback assets, metadata, provenance, and checksums unchanged
- editor hooks, stylesheet loading, and runtime assets unchanged

## Production archive audit

Built twice from exact commit `a8a60307986702efabce5fea1bf7bed9b7271070` without creating a tag.

- byte-identical archives
- 35 files
- 459,571 bytes
- SHA-256: `3dcdb61dcd0979528990657a8a912249bb3bfbd86f093c3f1bbc2886bc80d88e`
- one root directory: `better-font-awesome-library-3.0.1/`
- tests, agent files, CI and development configuration, development locks, build sources, `node_modules`, `vendor`, and release tooling excluded

The root Node development tree continues to report its pre-existing audit findings during `npm ci`; no dependency or tooling changes are included. The separately pinned shipped browser runtime audit is clean.
