### PR TITLE
Prepare BFAL 3.0.2 legacy transient correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.2
+
+- Treat a fully validated Font Awesome 5 release in the shared legacy transient as an incompatible cache miss when the immutable 7.x channel is selected, without diagnostics or transient mutation.
+- Continue serving the unchanged bundled Font Awesome 7.3.1 fallback and requesting asynchronous refresh exactly once, with no metadata HTTP on ordinary requests.
+- Preserve explicit 5.x transient acceptance, selected-channel validation diagnostics, provider behavior, and the 3.0.1 empty-provider correction.
+
 ## 3.0.1
 
 - Treat an exact empty array from `release_data_provider` as a normal indication that no local candidate is available, without recording a provider validation error.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The Better Font Awesome Library integrates validated Font Awesome Free metadata 
 ## Installation ##
 The Better Font Awesome Library should ideally be installed via Composer:
 ```
-composer require mickey-kay/better-font-awesome-library:3.0.1
+composer require mickey-kay/better-font-awesome-library:3.0.2
 ```
 
 Alternately, you can install the library manually, which can be useful for development and/or custom builds:
@@ -47,15 +47,15 @@ npm run build
 
 ## Stable release and rollback ##
 
-BFAL 3.0.1 is the stable release. Composer users can install it with:
+BFAL 3.0.2 is the stable release. Composer users can install it with:
 
 ```
-composer require mickey-kay/better-font-awesome-library:3.0.1
+composer require mickey-kay/better-font-awesome-library:3.0.2
 ```
 
-BFAL 3.0.1 defaults to Font Awesome 7 and preserves explicit Font Awesome 5 selection. Ordinary requests perform no metadata or candidate-validation HTTP. BFAL provides validated local metadata, packaged fallback assets, and explicit asynchronous refresh operations while consumers continue to own WordPress persistence, scheduling, locking, retry, freshness, and migration policy.
+BFAL 3.0.2 defaults to Font Awesome 7 and preserves explicit Font Awesome 5 selection. Ordinary requests perform no metadata or candidate-validation HTTP. BFAL provides validated local metadata, packaged fallback assets, and explicit asynchronous refresh operations while consumers continue to own WordPress persistence, scheduling, locking, retry, freshness, and migration policy.
 
-The corrective release treats an exact empty provider array as no locally available candidate, then continues to the established transient or bundled fallback. The packaged Font Awesome Free 7.3.1 fallback is unchanged, and WordPress uses `?ver=3.0.1` for BFAL stylesheet and script cache keys.
+The corrective release treats a fully validated Font Awesome 5 value in the shared legacy transient as an incompatible cache miss when the 7.x channel is selected. It adds no diagnostic, does not mutate the transient, continues to the unchanged packaged Font Awesome Free 7.3.1 fallback, and requests asynchronous refresh once. The BFAL 3.0.1 empty-provider correction remains intact, and WordPress uses `?ver=3.0.2` for BFAL stylesheet and script cache keys.
 
 To roll back to the Font Awesome 5 stable line, restore BFAL 2.1.0 and redeploy the resulting lockfile:
 
@@ -63,7 +63,7 @@ To roll back to the Font Awesome 5 stable line, restore BFAL 2.1.0 and redeploy 
 composer require mickey-kay/better-font-awesome-library:2.1.0 --with-all-dependencies
 ```
 
-BFAL follows versions published from repository tags. BFAL 3.0.1 preserves the first-caller singleton ownership contract, channels, metadata transport, validation, caching, fallback, refresh, routing, public APIs, precedence, and ownership behavior established in 3.0.0.
+BFAL follows versions published from repository tags. BFAL 3.0.2 preserves the first-caller singleton ownership contract, channels, metadata transport, validation, caching, fallback, refresh, routing, public APIs, precedence, and ownership behavior established in 3.0.0.
 
 ## Font Awesome 7 and BFAL 3 ##
 

--- a/better-font-awesome-library.php
+++ b/better-font-awesome-library.php
@@ -51,7 +51,7 @@ class Better_Font_Awesome_Library {
 	 *
 	 * @var    string
 	 */
-	const VERSION = '3.0.1';
+	const VERSION = '3.0.2';
 
 	/**
 	 * Font awesome GraphQL url.
@@ -621,7 +621,9 @@ class Better_Font_Awesome_Library {
 				return $this->release_data;
 			}
 
-			$this->set_validation_error( 'cache', $result );
+			if ( ! $this->is_valid_legacy_font_awesome_5_transient( $transient_value ) ) {
+				$this->set_validation_error( 'cache', $result );
+			}
 		}
 
 		// 4. Return validated bundled data immediately and request async refresh.
@@ -683,6 +685,25 @@ class Better_Font_Awesome_Library {
 		return $is_record
 			? Better_Font_Awesome_Release_Data_Validator::validate_record( $data )
 			: Better_Font_Awesome_Release_Data_Validator::validate_release( $data, $source );
+	}
+
+	/**
+	 * Recognize valid established Font Awesome 5 transient data on the 7.x channel.
+	 *
+	 * The shared legacy transient remains untouched and is treated as a cache
+	 * miss. Complete validation prevents arbitrary invalid values from being
+	 * silently ignored.
+	 *
+	 * @param mixed $data Legacy transient value.
+	 * @return bool Whether the value is valid Font Awesome 5 release data.
+	 */
+	private function is_valid_legacy_font_awesome_5_transient( $data ) {
+		if ( Better_Font_Awesome_Release_Channel::FONT_AWESOME_7 !== $this->release_channel ) {
+			return false;
+		}
+
+		$result = Better_Font_Awesome_Release_Data_Validator::validate_release( $data, 'transient' );
+		return $result['valid'];
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-font-awesome-library",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-font-awesome-library",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "GPL-2.0",
       "devDependencies": {
         "fontawesome-iconpicker": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-font-awesome-library",
   "description": "Better Font Awesome Library",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "main": " ",
   "devDependencies": {
     "fontawesome-iconpicker": "3.2.0",

--- a/runtime-assets/package-lock.json
+++ b/runtime-assets/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-font-awesome-library-runtime-assets",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-font-awesome-library-runtime-assets",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "dependencies": {
         "fontawesome-iconpicker": "3.2.0"
       }

--- a/runtime-assets/package.json
+++ b/runtime-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-font-awesome-library-runtime-assets",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "private": true,
   "description": "Audit manifest for third-party browser source copied into BFAL release archives.",
   "dependencies": {

--- a/tests/FontAwesome7RuntimeTest.php
+++ b/tests/FontAwesome7RuntimeTest.php
@@ -67,6 +67,112 @@ class FontAwesome7RuntimeTest extends BfalTestCase {
 		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
 	}
 
+	public function test_valid_legacy_five_transient_is_a_channel_miss_without_a_diagnostic() {
+		$legacy_transient = $this->get_valid_release();
+		$refresh_requests = array();
+		$GLOBALS['bfa_test_transients']['bfa-release-data'] = $legacy_transient;
+		$library = Better_Font_Awesome_Library::get_instance(
+			array(
+				'release_data_refresh_callback' => function ( $channel, $instance ) use ( &$refresh_requests ) {
+					$refresh_requests[] = array( $channel, $instance );
+				},
+			)
+		);
+
+		$this->assertSame( '7.3.1', $library->get_version() );
+		$this->assertSame( 'fallback', $library->get_release_record()['source'] );
+		$this->assertStringContainsString( '/font-awesome-7-fallback/', $library->get_stylesheet_url() );
+		$this->assertSame( '', $library->get_error( 'cache' ) );
+		$this->assertCount( 1, $refresh_requests );
+		$this->assertSame( '7.x', $refresh_requests[0][0] );
+		$this->assertSame( $library, $refresh_requests[0][1] );
+		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
+		$this->assertSame( $legacy_transient, $GLOBALS['bfa_test_transients']['bfa-release-data'] );
+		$this->assertSame( array(), $GLOBALS['bfa_test_transient_writes'] );
+	}
+
+	public function test_repeated_getters_after_legacy_five_transient_miss_are_stable() {
+		$refresh_requests = 0;
+		$GLOBALS['bfa_test_transients']['bfa-release-data'] = $this->get_valid_release();
+		$library = Better_Font_Awesome_Library::get_instance(
+			array(
+				'release_data_refresh_callback' => function () use ( &$refresh_requests ) {
+					++$refresh_requests;
+				},
+			)
+		);
+
+		$first_version = $library->get_version();
+		$first_url     = $library->get_stylesheet_url();
+		$library->get_icons();
+		$library->get_release_icons();
+		$library->get_release_assets();
+		$library->get_version();
+
+		$this->assertSame( '7.3.1', $first_version );
+		$this->assertSame( $first_version, $library->get_version() );
+		$this->assertSame( $first_url, $library->get_stylesheet_url() );
+		$this->assertSame( '', $library->get_error( 'cache' ) );
+		$this->assertSame( 1, $refresh_requests );
+		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
+	}
+
+	public function test_explicit_five_continues_accepting_the_valid_legacy_transient() {
+		$legacy_transient = $this->get_valid_release();
+		$refresh_requests = 0;
+		$GLOBALS['bfa_test_transients']['bfa-release-data'] = $legacy_transient;
+		$library = Better_Font_Awesome_Library::get_instance(
+			array(
+				'release_channel'               => '5.x',
+				'release_data_refresh_callback' => function () use ( &$refresh_requests ) {
+					++$refresh_requests;
+				},
+			)
+		);
+
+		$this->assertSame( '5.15.4', $library->get_version() );
+		$this->assertSame( 'transient', $library->get_release_record()['source'] );
+		$this->assertSame( $legacy_transient, $GLOBALS['bfa_test_transients']['bfa-release-data'] );
+		$this->assertSame( array(), $GLOBALS['bfa_test_transient_writes'] );
+		$this->assertSame( 0, $refresh_requests );
+		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
+	}
+
+	public function test_malformed_seven_transient_keeps_its_validation_diagnostic() {
+		$release = $this->get_schema_two_record( '7.4.1', 'malformed-transient' )['release'];
+		unset( $release['icons'] );
+		$GLOBALS['bfa_test_transients']['bfa-release-data'] = $release;
+
+		$library = Better_Font_Awesome_Library::get_instance();
+
+		$this->assertSame( '7.3.1', $library->get_version() );
+		$this->assertSame( 'fallback', $library->get_release_record()['source'] );
+		$this->assertSame( 'bfa_v2_icons_empty', $library->get_error( 'cache' )->get_error_code() );
+		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
+	}
+
+	public function test_valid_seven_transient_is_accepted_without_fallback_or_refresh() {
+		$release = $this->get_schema_two_record( '7.4.1', 'valid-transient' )['release'];
+		$refresh_requests = 0;
+		$GLOBALS['bfa_test_transients']['bfa-release-data'] = $release;
+		$library = Better_Font_Awesome_Library::get_instance(
+			array(
+				'release_data_refresh_callback' => function () use ( &$refresh_requests ) {
+					++$refresh_requests;
+				},
+			)
+		);
+
+		$this->assertSame( '7.4.1', $library->get_version() );
+		$this->assertSame( 'transient', $library->get_release_record()['source'] );
+		$this->assertSame(
+			'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.4.1/css/all.min.css',
+			$library->get_stylesheet_url()
+		);
+		$this->assertSame( 0, $refresh_requests );
+		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
+	}
+
 	public function test_malformed_nonempty_provider_result_keeps_the_validation_diagnostic() {
 		$refresh_requests = 0;
 		$library = Better_Font_Awesome_Library::get_instance(

--- a/tests/PublicCompatibilityTest.php
+++ b/tests/PublicCompatibilityTest.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/BfalTestCase.php';
 class PublicCompatibilityTest extends BfalTestCase {
 	public function test_public_constants_are_preserved() {
 		$this->assertSame( 'bfa', Better_Font_Awesome_Library::SLUG );
-		$this->assertSame( '3.0.1', Better_Font_Awesome_Library::VERSION );
+		$this->assertSame( '3.0.2', Better_Font_Awesome_Library::VERSION );
 		$this->assertSame( 'https://api.fontawesome.com', Better_Font_Awesome_Library::FONT_AWESOME_API_BASE_URL );
 		$this->assertSame( 'https://use.fontawesome.com/releases', Better_Font_Awesome_Library::FONT_AWESOME_CDN_BASE_URL );
 		$this->assertSame( 'inc/fallback-release-data.json', Better_Font_Awesome_Library::FALLBACK_RELEASE_DATA_PATH );
@@ -208,8 +208,8 @@ class PublicCompatibilityTest extends BfalTestCase {
 
 		$this->assertArrayHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_registered_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_registered_styles'] );
-		$this->assertSame( '3.0.1', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome']['version'] );
-		$this->assertSame( '3.0.1', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome-v4-shim']['version'] );
+		$this->assertSame( '3.0.2', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome']['version'] );
+		$this->assertSame( '3.0.2', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome-v4-shim']['version'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_enqueued_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_enqueued_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_inline_styles'] );
@@ -219,10 +219,10 @@ class PublicCompatibilityTest extends BfalTestCase {
 	public function test_admin_asset_cache_keys_use_the_release_version() {
 		$this->get_instance()->enqueue_admin_scripts();
 
-		$this->assertSame( '3.0.1', $GLOBALS['bfa_test_enqueued_styles']['bfa-admin']['version'] );
-		$this->assertSame( '3.0.1', $GLOBALS['bfa_test_enqueued_styles']['fontawesome-iconpicker']['version'] );
-		$this->assertSame( '3.0.1', $GLOBALS['bfa_test_enqueued_scripts']['bfa-admin']['version'] );
-		$this->assertSame( '3.0.1', $GLOBALS['bfa_test_enqueued_scripts']['fontawesome-iconpicker']['version'] );
+		$this->assertSame( '3.0.2', $GLOBALS['bfa_test_enqueued_styles']['bfa-admin']['version'] );
+		$this->assertSame( '3.0.2', $GLOBALS['bfa_test_enqueued_styles']['fontawesome-iconpicker']['version'] );
+		$this->assertSame( '3.0.2', $GLOBALS['bfa_test_enqueued_scripts']['bfa-admin']['version'] );
+		$this->assertSame( '3.0.2', $GLOBALS['bfa_test_enqueued_scripts']['fontawesome-iconpicker']['version'] );
 	}
 
 	public function test_documented_initialization_and_notice_filters_remain_active() {


### PR DESCRIPTION
## Summary

- Treat a fully validated Font Awesome 5 release in the shared legacy transient as an incompatible cache miss when the immutable 7.x channel is selected.
- Preserve the transient unchanged, serve the bundled Font Awesome 7.3.1 fallback, and request asynchronous refresh once without ordinary-request HTTP.
- Preserve explicit 5.x transient acceptance, valid 7.x local data, selected-channel diagnostics, provider behavior, and the BFAL 3.0.1 empty-provider correction.
- Prepare all established BFAL version surfaces and current-release documentation for 3.0.2.

## Published 3.0.1 regression proof

The regression tests were added while production code still matched exact published tag `3.0.1` at `759176801f12a3b8add646ac229cdbd9bd6a3d19`.

```text
FF  2 / 2

FontAwesome7RuntimeTest::test_valid_legacy_five_transient_is_a_channel_miss_without_a_diagnostic
FontAwesome7RuntimeTest::test_repeated_getters_after_legacy_five_transient_miss_are_stable

Both failed because get_error( 'cache' ) returned bfa_v2_version_unsupported.
Tests: 2, Assertions: 8, Failures: 2.
```

## Validation

- Focused Font Awesome 7 runtime suite: 27 tests, 172 assertions.
- Complete PHPUnit suite: 182 tests, 5,010 assertions.
- PHPCS: 6 of 6 files passed.
- PHPStan: no errors.
- `composer validate --strict`: passed.
- `composer audit`: no security vulnerability advisories found.
- `npm run build`: passed once on the final candidate.
- Font Awesome 7 fallback verification: 13 files verified for 7.3.1.
- Runtime asset audit: coverage verified and 0 shipped-runtime vulnerabilities.
- Production ZIP: 35 files, 459,949 bytes, SHA-256 `5a4130a1bc1b394d7011e1a67cf40eeaded4645240c554b993cb4e46d3f48d0d`.
- Two final archives built from `3a6eee5c3cfa4287d9753e68e1ea571737aaa76b` are byte-identical.
- BFA browser and WordPress integration suites were intentionally not run for this BFAL-only correction.
