### PR TITLE
Add optional bundled-local Font Awesome delivery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,9 @@
 ## Architecture and compatibility
 
 - Better Font Awesome Library is a reusable OSS library. Better Font Awesome is one consumer, not a privileged owner in every installation.
-- Preserve the live-ish, always-up-to-date architecture for validated Font Awesome Free metadata. The current supported channel is Font Awesome Free 5.x. Pro support is out of scope until the Free architecture is stable.
-- Bundled release and icon metadata is only a cold-start and failure fallback. Validated provider or last-known-good transient data takes precedence.
+- In the default `automatic` delivery mode, preserve the live-ish, always-up-to-date architecture for validated Font Awesome Free metadata. The supported channels are Font Awesome Free 7.x (default) and explicit 5.x. Pro support is out of scope until the Free architecture is stable.
+- In `automatic` mode, bundled release and icon metadata is only a cold-start and failure fallback. Validated provider or last-known-good transient data takes precedence.
+- The optional `bundled-local` delivery mode intentionally pins the active catalog, version, CSS, compatibility styles, and fonts to the same packaged FA7 Free release. Bypass providers and transients without mutation, request no background refresh, and never substitute remote assets. Updates arrive through BFAL or embedding-plugin updates. Explicit FA5 with `bundled-local` must fail closed without a channel switch. See README.md's Local asset delivery section for the public contract.
 - Ordinary frontend, admin, editor, REST, and other request paths must not perform metadata HTTP. Remote metadata transport belongs only in an explicit asynchronous worker path, and remote responses must be fully validated before adoption.
 - When BFA owns the BFAL instance, BFA owns WordPress-specific durable storage, freshness policy, WP-Cron scheduling, locking, retries, migration, and authenticated refresh controls.
 - The first `Better_Font_Awesome_Library::get_instance()` caller intentionally owns all initialization arguments. Later arguments are ignored. Hook priority is the supported ownership mechanism, and an earlier consumer can intentionally prevent BFA from owning that instance.

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ The object has the following public methods:
 (string) Returns the immutable selected Font Awesome channel, `7.x` by default or explicit `5.x`. Returns an empty string when an unsupported first-caller value has caused the runtime to fail closed.
 
 #### get_asset_delivery() ####
-(string) Returns the immutable first-caller mode, `automatic` or `bundled-local`. Returns an empty string for an unsupported mode. A supported mode is retained even when the channel or mode/channel combination is invalid; inspect `get_errors()` for configuration failures.
+(string) Returns the immutable first-caller mode, `automatic` or `bundled-local`. Returns an empty string when the mode, channel, or mode/channel combination is unsupported; inspect `get_errors()` for configuration failures. The internal selection remains immutable. A missing or invalid bundle does not invalidate the configuration, so the accessor still returns `bundled-local` in that case.
 
 #### request_release_data_refresh() ####
 Requests asynchronous refresh scheduling through the configured callback or `bfa_release_data_refresh_requested` action. This method performs no remote transport. It does nothing in bundled-local mode or after invalid mode/channel initialization.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Better Font Awesome Library
 1. [Font Awesome 7 and BFAL 3](https://github.com/MickeyKay/better-font-awesome-library#font-awesome-7-and-bfal-3)
 1. [Changelog](https://github.com/MickeyKay/better-font-awesome-library/blob/master/CHANGELOG.md)
 1. [Usage](https://github.com/MickeyKay/better-font-awesome-library#usage)
+1. [Local asset delivery](#local-asset-delivery)
 1. [Metadata lifecycle](https://github.com/MickeyKay/better-font-awesome-library#metadata-lifecycle)
 1. [Compatibility notes](https://github.com/MickeyKay/better-font-awesome-library#compatibility-notes)
 1. [Initialization Parameters](https://github.com/MickeyKay/better-font-awesome-library#initialization-parameters-args)
@@ -27,6 +28,7 @@ The Better Font Awesome Library integrates validated Font Awesome Free metadata 
 * Returns validated local metadata immediately from a provider, transient, or bundled fallback.
 * Exposes an explicit, bounded refresh operation for consumer-controlled asynchronous workers.
 * Generates an easy-to-use [PHP object](#the-better-font-awesome-library-object) that contains all relevant info for the version of Font Awesome you're using, including: version, stylesheet URL, array of available icons, and prefix used (`icon` or `fa`).
+* Offers optional bundled-local asset delivery for the packaged Font Awesome Free 7 catalog, CSS, and fonts.
 * Loads the exact assets coupled to the immutable selected Font Awesome Free channel.
 * Includes a TinyMCE drop-down shortcode generator.
 * Includes validated Font Awesome Free 7.3.1 CSS, WOFF2, and metadata as the immediate default fallback, plus the established Font Awesome Free 5.14.0 metadata fallback for explicit 5.x consumers. The `bfa_fallback_release_data_path` filter remains available for the 5.x fallback.
@@ -73,7 +75,7 @@ BFAL 3 defaults to the `7.x` release channel when the first caller supplies no `
 
 The 7.x channel validates and loads the packaged Font Awesome Free 7.3.1 baseline immediately. Its CSS and WOFF2 URLs are derived from the BFAL installation URL, so activation needs no HTTP request, cron run, migration, pending state, or setting. Normal frontend, admin, editor, REST, shortcode, picker, and getter paths perform no metadata HTTP.
 
-An explicit 7.x background refresh discovers only the latest supported 7.x Free release. A same-version check uses one Font Awesome metadata request. A genuinely newer candidate is limited to 18 total requests, 4 MiB of response bodies, and 30 seconds. It must pass exact npm publication, cdnjs and jsDelivr byte comparison, CSS SRI, required WOFF2, CSS-to-font reference, family, style, icon, and alias validation. The worker returns one complete schema-2 record or a sanitized `WP_Error`; BFAL does not persist 7.x refresh results. Consumer code owns last-known-good storage, scheduling, locking, retry, and freshness policy.
+In automatic mode, an explicit 7.x background refresh discovers only the latest supported 7.x Free release. A same-version check uses one Font Awesome metadata request. A genuinely newer candidate is limited to 18 total requests, 4 MiB of response bodies, and 30 seconds. It must pass exact npm publication, cdnjs and jsDelivr byte comparison, CSS SRI, required WOFF2, CSS-to-font reference, family, style, icon, and alias validation. The worker returns one complete schema-2 record or a sanitized `WP_Error`; BFAL does not persist 7.x refresh results. Consumer code owns last-known-good storage, scheduling, locking, retry, and freshness policy.
 
 The 7.x channel never crosses automatically to Font Awesome 8. Supporting another Font Awesome major requires a separately reviewed BFAL compatibility release.
 
@@ -104,6 +106,7 @@ add_action( 'init', 'my_prefix_load_bfa' );
       'release_data_provider' => null,
       'release_data_refresh_callback' => null,
       'release_channel' => '7.x',
+      'asset_delivery' => 'automatic',
     );
 
     // Initialize the Better Font Awesome Library.
@@ -119,22 +122,51 @@ The Better Font Awesome Library is designed to work in conjunction with the [Bet
 1. Initialize later so Better Font Awesome reaches the singleton first. Your later arguments are ignored, and Better Font Awesome owns the configuration. This is the default behavior shown above by initializing on the `init` hook at priority `10`.
 1. Initialize earlier to take ownership. Better Font Awesome's later arguments are ignored and cannot override yours.
 
-This first-caller contract is intentional and applies to every initialization argument, including the release channel, release-data provider, and refresh callback. Hook priority determines ownership. BFAL does not provide post-construction registration, reset, mutation, or ownership transfer.
+This first-caller contract is intentional and applies to every initialization argument, including asset delivery mode, release channel, release-data provider, and refresh callback. Hook priority determines ownership. BFAL does not provide post-construction registration, reset, mutation, or ownership transfer.
+
+## Local asset delivery ##
+
+The optional `asset_delivery` initialization argument accepts exactly two string values:
+
+* `automatic` (default) preserves existing behavior for both `7.x` and explicit `5.x`. Validated provider or transient metadata takes precedence over the bundled fallback. Accepted releases use their matching CDN assets; the FA7 bundled fallback uses packaged assets. Consumer-managed background refresh can discover newer releases within the selected channel.
+* `bundled-local` selects only the packaged Font Awesome Free 7 release. The active version, icon catalog, picker data, CSS, compatibility styles, and WOFF2 fonts all come from that bundle immediately. New Font Awesome releases arrive through BFAL updates, or through updates to a plugin that packages BFAL. Provider data and legacy transients are neither read nor mutated, even if they contain a matching or newer release.
+
+```php
+$library = Better_Font_Awesome_Library::get_instance( array(
+    'asset_delivery' => 'bundled-local',
+    'release_channel' => '7.x',
+) );
+
+// Use the effective first caller's mode when deciding whether to schedule work.
+if ( 'automatic' === $library->get_asset_delivery() ) {
+    // Apply your integration's scheduling and freshness policy.
+}
+```
+
+The first `get_instance()` caller owns the mode and channel after the existing initialization filters run. Later callers and later filter changes cannot change that selection. Hook priority is the ownership mechanism; an earlier consumer can intentionally prevent Better Font Awesome from owning BFAL. Integrations must inspect `get_asset_delivery()` instead of inferring mode from URLs or record provenance. The packaged record retains its existing `source => 'fallback'` provenance in both modes.
+
+Local delivery supports FA7 Free only. Explicit `release_channel => '5.x'` with `bundled-local` fails closed with `get_error( 'delivery' )` code `bfa_asset_delivery_channel_unsupported`, no remote requests, and no channel switch. An unsupported mode fails closed with `bfa_asset_delivery_unsupported`. In either case BFAL exposes no active release, icons, or stylesheet URLs. Fix initialization for a subsequent request; a later caller cannot repair the established instance.
+
+In local mode, `request_release_data_refresh()` is a no-op: neither the callback nor the refresh action runs. `refresh_release_data()` returns a `WP_Error` with code `bfa_refresh_disabled`, performs zero HTTP or persistence, and leaves the active record unchanged. This is an intentional disabled operation, not a retryable refresh failure, and it does not add an admin diagnostic. Integrations should skip scheduling and retries in local mode and preserve their existing remote metadata for a future automatic-mode request. Invalid initialization instead returns its configuration error from explicit refresh.
+
+If bundled metadata cannot be read or validated, or a required CSS/font file is missing, unreadable, or empty at initialization, BFAL reports a fallback error and exposes no active catalog or stylesheet URLs. Missing assets use error code `bfa_bundled_asset_unavailable`; metadata errors retain the existing validator codes. Restore a complete BFAL package to recover. A browser delivery failure leaves the affected icons unavailable. BFAL never substitutes third-party assets or requests refresh work in local mode.
+
+Stylesheet handles, loading flags, editor integration, and existing integrity/CORS handling remain unchanged. FA5 compatibility font faces are included for legacy markup rendered with FA7; this does not add FA5 asset self-hosting. Optional v4 styles still follow `include_v4_shim`. CSS font references stay inside the bundled asset tree and URLs use the BFAL installation URL. Sites that rewrite installation URLs through a CDN must account for that infrastructure separately. This feature controls BFAL's Font Awesome asset delivery only, not requests made by other plugins, themes, or site infrastructure.
 
 ## Metadata lifecycle ##
 
-Normal frontend, admin, editor, REST, and cron-triggering requests never call the Font Awesome metadata service synchronously. BFAL resolves release data only for the immutable channel selected during first-caller initialization, in this order:
+Normal frontend, admin, editor, REST, and cron-triggering requests never call the Font Awesome metadata service synchronously. In automatic mode, BFAL resolves release data only for the immutable channel selected during first-caller initialization, in this order:
 
 1. The per-request validated value.
 2. An optional `release_data_provider` callable that returns already-resolved local data.
 3. A validated value from the established `bfa-release-data` transient.
 4. The validated bundled fallback for the selected channel: Font Awesome Free 7.3.1 for `7.x`, or the established Font Awesome Free 5.14.0 fallback for explicit `5.x`.
 
-When BFAL reaches the fallback, it invokes `release_data_refresh_callback` once if configured. Otherwise it fires `bfa_release_data_refresh_requested` with the supported channel and library instance. The handler must only schedule work and return promptly. Scheduling, locking, durable last-known-good persistence, retry backoff, jitter, and freshness policy belong to the consumer.
+When automatic mode reaches the fallback, it invokes `release_data_refresh_callback` once if configured. Otherwise it fires `bfa_release_data_refresh_requested` with the supported channel and library instance. The handler must only schedule work and return promptly. Scheduling, locking, durable last-known-good persistence, retry backoff, jitter, and freshness policy belong to the consumer.
 
 A provider may return a release array or a declared BFAL release record. An exact empty array means that the provider has no locally available candidate yet. Declared records must use the exact supported `schema_version`, `channel`, and `edition`, an allowed `source`, and a fully valid nested release. BFAL rejects mismatches rather than discarding or normalizing them.
 
-An asynchronous worker can call `refresh_release_data()`. For explicit `5.x`, the established operation retains its existing validated transient behavior and release-array return value. For `7.x`, one bounded attempt returns a complete validated schema-2 record or a sanitized `WP_Error` and performs no BFAL persistence. Both paths require TLS, reject redirects and unsafe URLs, and leave the prior validated data untouched on failure.
+In automatic mode, an asynchronous worker can call `refresh_release_data()`. For explicit `5.x`, the established operation retains its existing validated transient behavior and release-array return value. For `7.x`, one bounded attempt returns a complete validated schema-2 record or a sanitized `WP_Error` and performs no BFAL persistence. Both paths require TLS, reject redirects and unsafe URLs, and leave the prior validated data untouched on failure.
 
 The Font Awesome API and CDN are external services. Consumers should document when they contact those services and apply the consent, privacy, scheduling, and persistence policy appropriate to their application.
 
@@ -176,6 +208,9 @@ The following arguments can be used to initialize the library using `Better_Font
 (boolean) Loads a TinyMCE drop-down list of available icons (based on the active Font Awesome version), which generates an `[icon]` shortcode.
 * `true` (default)
 * `false`
+
+#### $args['asset_delivery'] ####
+(string) Immutable delivery mode: `automatic` (default) or `bundled-local`. Local delivery is FA7-only and pins the catalog and all Font Awesome assets to the packaged release. See [local asset delivery](#local-asset-delivery) for update, ownership, refresh, and failure behavior.
 
 #### $args['release_data_provider'] ####
 
@@ -268,11 +303,14 @@ The object has the following public methods:
 #### get_release_channel() ####
 (string) Returns the immutable selected Font Awesome channel, `7.x` by default or explicit `5.x`. Returns an empty string when an unsupported first-caller value has caused the runtime to fail closed.
 
+#### get_asset_delivery() ####
+(string) Returns the immutable first-caller mode, `automatic` or `bundled-local`. Returns an empty string for an unsupported mode. A supported mode is retained even when the channel or mode/channel combination is invalid; inspect `get_errors()` for configuration failures.
+
 #### request_release_data_refresh() ####
-Requests asynchronous refresh scheduling through the configured callback or `bfa_release_data_refresh_requested` action. This method performs no remote transport.
+Requests asynchronous refresh scheduling through the configured callback or `bfa_release_data_refresh_requested` action. This method performs no remote transport. It does nothing in bundled-local mode or after invalid mode/channel initialization.
 
 #### refresh_release_data() ####
-(array|WP_Error) Performs one bounded refresh attempt in an explicit worker context. Consumers own locking, retry, and durable persistence policy.
+(array|WP_Error) In automatic mode, performs one bounded refresh attempt in an explicit worker context. Consumers own locking, retry, and durable persistence policy. Bundled-local mode returns `WP_Error( 'bfa_refresh_disabled', ... )` without HTTP, mutation, or an admin diagnostic; do not retry this disabled operation. Invalid initialization returns its configuration error.
 
 #### get_prefix() ####
 (string) Returns the version-dependent prefix ('fa' or 'icon') that is used in the icons' CSS classes.
@@ -391,7 +429,7 @@ Applied to the boolean that determines whether or not to suppress all Font Aweso
 ## Actions ##
 
 #### bfa_release_data_refresh_requested ####
-Fires once per BFAL request when no valid provider or transient value is available and bundled fallback data is selected. Handlers receive the immutable selected channel (`5.x` or `7.x`) and BFAL instance. Handlers must schedule asynchronous work and return promptly.
+In automatic mode, fires once per BFAL request when no valid provider or transient value is available and bundled fallback data is selected. Handlers receive the immutable selected channel (`5.x` or `7.x`) and BFAL instance. Handlers must schedule asynchronous work and return promptly. This action never fires in bundled-local mode.
 
 ### Deprecated
 

--- a/better-font-awesome-library.php
+++ b/better-font-awesome-library.php
@@ -1844,9 +1844,13 @@ class Better_Font_Awesome_Library {
 	/**
 	 * Get the immutable asset delivery mode.
 	 *
-	 * @return string automatic or bundled-local; empty for an unsupported mode.
+	 * @return string automatic or bundled-local; empty for an unsupported configuration.
 	 */
 	public function get_asset_delivery() {
+		if ( $this->release_channel_invalid || $this->asset_delivery_invalid ) {
+			return '';
+		}
+
 		return $this->asset_delivery;
 	}
 

--- a/better-font-awesome-library.php
+++ b/better-font-awesome-library.php
@@ -132,6 +132,7 @@ class Better_Font_Awesome_Library {
 		'release_data_provider'        => null,
 		'release_data_refresh_callback' => null,
 		'release_channel'              => '7.x',
+		'asset_delivery'               => 'automatic',
 	);
 
 	/**
@@ -154,6 +155,20 @@ class Better_Font_Awesome_Library {
 	 * @var bool
 	 */
 	private $release_channel_invalid = false;
+
+	/**
+	 * Immutable asset delivery mode selected with the first caller's channel.
+	 *
+	 * @var string
+	 */
+	private $asset_delivery = '';
+
+	/**
+	 * Whether the selected delivery mode or mode/channel combination is invalid.
+	 *
+	 * @var bool
+	 */
+	private $asset_delivery_invalid = false;
 
 	/**
 	 * Root URL of the library.
@@ -416,9 +431,9 @@ class Better_Font_Awesome_Library {
 		$this->args = apply_filters( 'bfa_init_args', $this->args );
 
 		/*
-		 * Resolve the selected channel exactly once. The established filter remains
-		 * available, but later calls to load() and later singleton callers cannot
-		 * mutate the first caller's selection.
+		 * Resolve the selected channel and delivery mode exactly once. Existing
+		 * filters remain available, but later calls to load() and later singleton
+		 * callers cannot mutate the first caller's selection.
 		 */
 		if ( ! $this->release_channel_resolved ) {
 			$selected = array_key_exists( 'release_channel', $this->args ) ? $this->args['release_channel'] : null;
@@ -432,10 +447,23 @@ class Better_Font_Awesome_Library {
 				$this->set_error( 'channel', 'bfa_channel_unsupported', 'The selected Font Awesome release channel is not supported.' );
 			}
 
+			$delivery = array_key_exists( 'asset_delivery', $this->args ) ? $this->args['asset_delivery'] : null;
+			if ( 'automatic' === $delivery || 'bundled-local' === $delivery ) {
+				$this->asset_delivery = $delivery;
+				if ( 'bundled-local' === $delivery && Better_Font_Awesome_Release_Channel::FONT_AWESOME_5 === $this->release_channel ) {
+					$this->asset_delivery_invalid = true;
+					$this->set_error( 'delivery', 'bfa_asset_delivery_channel_unsupported', 'Bundled-local asset delivery requires the Font Awesome 7 release channel.' );
+				}
+			} else {
+				$this->asset_delivery_invalid = true;
+				$this->set_error( 'delivery', 'bfa_asset_delivery_unsupported', 'The selected Font Awesome asset delivery mode is not supported.' );
+			}
+
 			$this->release_channel_resolved = true;
 		}
 
 		$this->args['release_channel'] = $this->release_channel;
+		$this->args['asset_delivery']  = $this->asset_delivery;
 
 		/**
 		 * Filter the wp_remote_get args.
@@ -576,6 +604,25 @@ class Better_Font_Awesome_Library {
 			return $this->get_empty_release_data();
 		}
 
+		if ( 'bundled-local' === $this->asset_delivery ) {
+			$paths = array_merge(
+				array_column( $result['record']['release']['srisByLicense']['free'], 'path' ),
+				array(
+					'webfonts/fa-brands-400.woff2',
+					'webfonts/fa-regular-400.woff2',
+					'webfonts/fa-solid-900.woff2',
+					'webfonts/fa-v4compatibility.woff2',
+				)
+			);
+			foreach ( $paths as $asset_path ) {
+				$local_path = plugin_dir_path( __FILE__ ) . self::FONT_AWESOME_7_FALLBACK_PATH . $asset_path;
+				if ( ! is_file( $local_path ) || ! is_readable( $local_path ) || 0 === filesize( $local_path ) ) {
+					$this->set_error( 'fallback', 'bfa_bundled_asset_unavailable', 'A bundled Font Awesome asset is missing, unreadable, or empty. Restore the BFAL package to use local asset delivery.' );
+					return $this->get_empty_release_data();
+				}
+			}
+		}
+
 		$this->release_record = $result['record'];
 		$this->using_bundled_font_awesome_7_fallback = true;
 		return $result['record']['release'];
@@ -594,12 +641,18 @@ class Better_Font_Awesome_Library {
 	 * @return  array  Release data.
 	 */
 	private function get_font_awesome_release_data() {
-		if ( $this->release_channel_invalid ) {
+		if ( $this->release_channel_invalid || $this->asset_delivery_invalid ) {
 			return $this->get_empty_release_data();
 		}
 
 		// 1. Reuse validated instance data for this request.
 		if ( ! empty( $this->release_data ) ) {
+			return $this->release_data;
+		}
+
+		// Local delivery pins metadata and assets to the same packaged release.
+		if ( 'bundled-local' === $this->asset_delivery ) {
+			$this->release_data = $this->get_fallback_release_data();
 			return $this->release_data;
 		}
 
@@ -776,6 +829,10 @@ class Better_Font_Awesome_Library {
 			return $this->root_url . self::FONT_AWESOME_7_FALLBACK_PATH . $path;
 		}
 
+		if ( 'bundled-local' === $this->asset_delivery ) {
+			return '';
+		}
+
 		return sprintf( '%s/%s/%s', self::FONT_AWESOME_7_CDN_BASE_URL, $version, $path );
 	}
 
@@ -783,12 +840,13 @@ class Better_Font_Awesome_Library {
 	 * Request asynchronous release data refresh work from a consumer.
 	 *
 	 * The callback or action handler must schedule work and return promptly. BFAL
-	 * does not run remote transport from this method.
+	 * does not run remote transport from this method. Bundled-local delivery
+	 * never requests refresh work, including when the bundle cannot be loaded.
 	 *
 	 * @since 2.1.0
 	 */
 	public function request_release_data_refresh() {
-		if ( $this->release_channel_invalid || $this->refresh_requested ) {
+		if ( $this->release_channel_invalid || $this->asset_delivery_invalid || 'bundled-local' === $this->asset_delivery || $this->refresh_requested ) {
 			return;
 		}
 
@@ -817,6 +875,8 @@ class Better_Font_Awesome_Library {
 	 * Consumers own scheduling, locking, retry backoff, and durable last-known-
 	 * good persistence. This method performs one bounded refresh attempt and
 	 * only replaces the established transient after complete validation.
+	 * Bundled-local delivery returns bfa_refresh_disabled as a WP_Error without
+	 * HTTP, persistence, or changing the active record. It is not a retryable failure.
 	 *
 	 * @since 2.1.0
 	 *
@@ -825,6 +885,14 @@ class Better_Font_Awesome_Library {
 	public function refresh_release_data() {
 		if ( $this->release_channel_invalid ) {
 			return $this->get_error( 'channel' );
+		}
+
+		if ( $this->asset_delivery_invalid ) {
+			return $this->get_error( 'delivery' );
+		}
+
+		if ( 'bundled-local' === $this->asset_delivery ) {
+			return new WP_Error( 'bfa_refresh_disabled', 'Metadata refresh is disabled for bundled-local asset delivery. Update the BFAL package to update Font Awesome.' );
 		}
 
 		if ( Better_Font_Awesome_Release_Channel::FONT_AWESOME_7 === $this->release_channel ) {
@@ -1375,7 +1443,7 @@ class Better_Font_Awesome_Library {
 	 * @since  2.0.1
 	 */
 	public function register_v4_shim_inline_css () {
-		if ( Better_Font_Awesome_Release_Channel::FONT_AWESOME_7 === $this->release_channel ) {
+		if ( $this->asset_delivery_invalid || 'bundled-local' === $this->asset_delivery || Better_Font_Awesome_Release_Channel::FONT_AWESOME_7 === $this->release_channel ) {
 			return;
 		}
 
@@ -1771,6 +1839,15 @@ class Better_Font_Awesome_Library {
 	 */
 	public function get_release_channel() {
 		return $this->release_channel;
+	}
+
+	/**
+	 * Get the immutable asset delivery mode.
+	 *
+	 * @return string automatic or bundled-local; empty for an unsupported mode.
+	 */
+	public function get_asset_delivery() {
+		return $this->asset_delivery;
 	}
 
 	/**

--- a/tests/AssetDeliveryTest.php
+++ b/tests/AssetDeliveryTest.php
@@ -132,24 +132,38 @@ class AssetDeliveryTest extends BfalTestCase {
 		);
 	}
 
-	/** @dataProvider invalid_modes */
-	public function test_invalid_mode_fails_closed_and_cannot_be_replaced( $mode, $channel, $code, $effective ) {
+	/** @dataProvider invalid_configurations */
+	public function test_invalid_configuration_reports_no_mode_and_cannot_be_replaced( $mode, $channel, $process, $code ) {
 		$library = Better_Font_Awesome_Library::get_instance( array( 'asset_delivery' => $mode, 'release_channel' => $channel ) );
-		$this->assertSame( $effective, $library->get_asset_delivery() );
-		$this->assertSame( $channel, $library->get_release_channel() );
-		$this->assertSame( $code, $library->get_error( 'delivery' )->get_error_code() );
-		$this->assertSame( $library->get_error( 'delivery' ), $library->refresh_release_data() );
+		$this->assertSame( '', $library->get_asset_delivery() );
+		$this->assertSame( 'unsupported' === $channel ? '' : $channel, $library->get_release_channel() );
+		$this->assertSame( $code, $library->get_error( $process )->get_error_code() );
+		$this->assertSame( $library->get_error( $process ), $library->refresh_release_data() );
 		$this->assertSame( $library, Better_Font_Awesome_Library::get_instance( array( 'asset_delivery' => 'automatic', 'release_channel' => '7.x' ) ) );
+		add_filter( 'bfa_init_args', function ( $args ) {
+			$args['asset_delivery'] = 'automatic';
+			$args['release_channel'] = '7.x';
+			return $args;
+		} );
+		$library->load();
+		$this->assertSame( '', $library->get_asset_delivery() );
+		$this->assertSame( 'unsupported' === $channel ? '' : $channel, $library->get_release_channel() );
+		$this->assertSame( $library->get_error( $process ), $library->refresh_release_data() );
+		if ( 'delivery' === $process ) {
+			$library->register_v4_shim_inline_css();
+		}
 		$this->assert_closed( $library );
 	}
 
-	public static function invalid_modes() {
+	public static function invalid_configurations() {
 		return array(
-			array( 'remote-secret', '7.x', 'bfa_asset_delivery_unsupported', '' ),
-			array( null, '7.x', 'bfa_asset_delivery_unsupported', '' ),
-			array( array(), '7.x', 'bfa_asset_delivery_unsupported', '' ),
-			array( false, '7.x', 'bfa_asset_delivery_unsupported', '' ),
-			array( 'bundled-local', '5.x', 'bfa_asset_delivery_channel_unsupported', 'bundled-local' ),
+			array( 'remote-secret', '7.x', 'delivery', 'bfa_asset_delivery_unsupported' ),
+			array( null, '7.x', 'delivery', 'bfa_asset_delivery_unsupported' ),
+			array( array(), '7.x', 'delivery', 'bfa_asset_delivery_unsupported' ),
+			array( false, '7.x', 'delivery', 'bfa_asset_delivery_unsupported' ),
+			array( 'bundled-local', '5.x', 'delivery', 'bfa_asset_delivery_channel_unsupported' ),
+			array( 'automatic', 'unsupported', 'channel', 'bfa_channel_unsupported' ),
+			array( 'bundled-local', 'unsupported', 'channel', 'bfa_channel_unsupported' ),
 		);
 	}
 
@@ -188,10 +202,12 @@ class AssetDeliveryTest extends BfalTestCase {
 				'release_data_refresh_callback' => function () { $this->fail( 'Refresh requested for broken bundle.' ); },
 			) );
 			$this->assertInstanceOf( WP_Error::class, $library->get_error( 'fallback' ) );
+			$this->assertSame( 'bundled-local', $library->get_asset_delivery(), 'A bundle failure does not invalidate the configured delivery mode.' );
 			if ( 'metadata.json' !== $path ) {
 				$this->assertSame( 'bfa_bundled_asset_unavailable', $library->get_error( 'fallback' )->get_error_code() );
 			}
 			$this->assertSame( 'bfa_refresh_disabled', $library->refresh_release_data()->get_error_code() );
+			$library->register_v4_shim_inline_css();
 			$this->assert_closed( $library );
 			$this->assertSame( $candidate, $GLOBALS['bfa_test_transients']['bfa-release-data'] );
 		} finally {
@@ -242,7 +258,6 @@ class AssetDeliveryTest extends BfalTestCase {
 		$this->assertSame( array(), $library->get_icons() );
 		$this->assertSame( array(), $library->get_release_assets() );
 		$library->register_font_awesome_css();
-		$library->register_v4_shim_inline_css();
 		$library->request_release_data_refresh();
 		$this->assertSame( array(), $GLOBALS['bfa_test_registered_styles'] );
 		$this->assertSame( array(), $GLOBALS['bfa_test_inline_styles'] );

--- a/tests/AssetDeliveryTest.php
+++ b/tests/AssetDeliveryTest.php
@@ -1,0 +1,259 @@
+<?php
+
+require_once __DIR__ . '/BfalTestCase.php';
+
+class AssetDeliveryTest extends BfalTestCase {
+	/** @dataProvider automatic_modes */
+	public function test_automatic_preserves_provider_selection( $mode, $channel ) {
+		$record = '7.x' === $channel ? $this->bundle() : $this->get_valid_release();
+		$args = array(
+			'release_channel' => $channel,
+			'release_data_provider' => function () use ( $record ) { return $record; },
+		);
+		if ( null !== $mode ) {
+			$args['asset_delivery'] = $mode;
+		}
+		$library = Better_Font_Awesome_Library::get_instance( $args );
+		$this->assertSame( 'automatic', $library->get_asset_delivery() );
+		$this->assertSame( $channel, $library->get_release_channel() );
+		$this->assertSame(
+			'7.x' === $channel ? 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.3.1/css/all.min.css' : 'https://use.fontawesome.com/releases/v5.15.4/css/all.css',
+			$library->get_stylesheet_url()
+		);
+		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
+	}
+
+	public static function automatic_modes() {
+		return array( array( null, '7.x' ), array( 'automatic', '7.x' ), array( null, '5.x' ), array( 'automatic', '5.x' ) );
+	}
+
+	/** @dataProvider ignored_candidates */
+	public function test_local_ignores_provider_and_transient_without_reading_or_mutating_them( $candidate ) {
+		$record = $this->candidate( $candidate );
+		$GLOBALS['bfa_test_transients']['bfa-release-data'] = $record;
+		$before = $GLOBALS['bfa_test_transients'];
+		$library = Better_Font_Awesome_Library::get_instance(
+			array(
+				'asset_delivery' => 'bundled-local',
+				'release_data_provider' => function () use ( $record ) {
+					$this->fail( 'Local delivery must not invoke a provider.' );
+					return $record;
+				},
+				'release_data_refresh_callback' => function () { $this->fail( 'Local delivery must not schedule refresh.' ); },
+			)
+		);
+		$this->assertSame( $this->bundle(), $library->get_release_record() );
+		$this->assertSame( 'bundled-local', $library->get_asset_delivery() );
+		$this->assertSame( '7.x', $library->get_release_channel() );
+		$this->assertSame( $this->bundle()['release']['version'], $library->get_version() );
+		$this->assertSame( array(), $library->get_errors() );
+		$library->load();
+		$library->get_icons();
+		$library->get_release_icons();
+		$library->register_font_awesome_css();
+		$library->enqueue_admin_scripts();
+		$library->render_shortcode( array( 'name' => 'close' ) );
+		$library->request_release_data_refresh();
+		$this->assertSame( 'bfa_refresh_disabled', $library->refresh_release_data()->get_error_code() );
+		$this->assertSame( $this->bundle(), $library->get_release_record() );
+		$this->assertSame( $before, $GLOBALS['bfa_test_transients'] );
+		$this->assertSame( array(), $GLOBALS['bfa_test_transient_reads'] );
+		$this->assertSame( array(), $GLOBALS['bfa_test_transient_writes'] );
+		$this->assertSame( array(), $library->get_errors(), 'Disabled refresh is a result, not an admin diagnostic.' );
+		$this->assert_no_refresh_work();
+	}
+
+	public static function ignored_candidates() {
+		return array_map( function ( $name ) { return array( $name ); }, array( 'empty', 'matching', 'newer', 'wrong-channel', 'malformed' ) );
+	}
+
+	public function test_local_catalog_picker_styles_and_editor_share_the_bundle() {
+		$library = Better_Font_Awesome_Library::get_instance( array( 'asset_delivery' => 'bundled-local', 'include_v4_shim' => true ) );
+		$library->register_font_awesome_css();
+		$record = $this->bundle();
+		$this->assertSame( $record['release']['srisByLicense']['free'], $library->get_release_assets() );
+		$this->assertSame( array_column( $record['release']['icons'], 'id' ), array_column( $library->get_release_icons(), 'id' ) );
+		$expected_picker = array();
+		foreach ( $record['release']['icons'] as $icon ) {
+			foreach ( $icon['familyStylesByLicense']['free'] as $style ) {
+				$expected_picker[] = $icon['id'] . ':' . $style['style'];
+			}
+		}
+		$actual_picker = array_map( function ( $icon ) { return $icon['slug'] . ':' . $icon['style']; }, $library->get_icons() );
+		sort( $expected_picker );
+		sort( $actual_picker );
+		$this->assertSame( $expected_picker, $actual_picker );
+
+		$root = 'https://example.test/plugin/inc/font-awesome-7-fallback/';
+		$this->assertSame( $root . 'css/all.min.css', $library->get_stylesheet_url() );
+		$this->assertSame( $root . 'css/v4-shims.min.css', $library->get_stylesheet_url_v4_shim() );
+		$expected = array(
+			'bfa-font-awesome' => 'css/all.min.css',
+			'bfa-font-awesome-v5-compat' => 'css/v5-font-face.min.css',
+			'bfa-font-awesome-v4-font-face' => 'css/v4-font-face.min.css',
+			'bfa-font-awesome-v4-shim' => 'css/v4-shims.min.css',
+		);
+		$this->assertSame( array_keys( $expected ), array_keys( $GLOBALS['bfa_test_registered_styles'] ) );
+		foreach ( $expected as $handle => $path ) {
+			$this->assertSame( $root . $path, $GLOBALS['bfa_test_registered_styles'][ $handle ]['src'] );
+			$tag = apply_filters( 'style_loader_tag', '<link id="' . $handle . '-css" rel="stylesheet" href="' . $root . $path . '" />', $handle );
+			$this->assertStringContainsString( 'integrity="sha512-', $tag );
+			$this->assertStringContainsString( 'crossorigin="anonymous"', $tag );
+		}
+		$this->assertSame( array_map( function ( $path ) use ( $root ) { return $root . $path; }, array_values( $expected ) ), get_editor_stylesheets() );
+		$this->assertSame( array(), $GLOBALS['bfa_test_inline_styles'] );
+		$library->request_release_data_refresh();
+		$this->assert_no_refresh_work();
+	}
+
+	/** @dataProvider owner_modes */
+	public function test_first_caller_owns_mode_and_channel_even_after_filter_changes_and_reload( $mode, $channel, $later_mode, $later_channel ) {
+		$library = Better_Font_Awesome_Library::get_instance( array( 'asset_delivery' => $mode, 'release_channel' => $channel ) );
+		$record = $library->get_release_record();
+		$later = Better_Font_Awesome_Library::get_instance( array( 'asset_delivery' => $later_mode, 'release_channel' => $later_channel ) );
+		add_filter( 'bfa_init_args', function ( $args ) use ( $later_mode, $later_channel ) {
+			$args['asset_delivery'] = $later_mode;
+			$args['release_channel'] = $later_channel;
+			return $args;
+		} );
+		add_filter( 'bfa_font_awesome_release_channel', function () use ( $later_channel ) { return $later_channel; } );
+		$library->load();
+		$this->assertSame( $library, $later );
+		$this->assertSame( $mode, $library->get_asset_delivery() );
+		$this->assertSame( $channel, $library->get_release_channel() );
+		$this->assertSame( $record, $library->get_release_record() );
+	}
+
+	public static function owner_modes() {
+		return array(
+			array( 'bundled-local', '7.x', 'automatic', '5.x' ),
+			array( 'automatic', '7.x', 'bundled-local', '5.x' ),
+			array( 'automatic', '5.x', 'bundled-local', '7.x' ),
+		);
+	}
+
+	/** @dataProvider invalid_modes */
+	public function test_invalid_mode_fails_closed_and_cannot_be_replaced( $mode, $channel, $code, $effective ) {
+		$library = Better_Font_Awesome_Library::get_instance( array( 'asset_delivery' => $mode, 'release_channel' => $channel ) );
+		$this->assertSame( $effective, $library->get_asset_delivery() );
+		$this->assertSame( $channel, $library->get_release_channel() );
+		$this->assertSame( $code, $library->get_error( 'delivery' )->get_error_code() );
+		$this->assertSame( $library->get_error( 'delivery' ), $library->refresh_release_data() );
+		$this->assertSame( $library, Better_Font_Awesome_Library::get_instance( array( 'asset_delivery' => 'automatic', 'release_channel' => '7.x' ) ) );
+		$this->assert_closed( $library );
+	}
+
+	public static function invalid_modes() {
+		return array(
+			array( 'remote-secret', '7.x', 'bfa_asset_delivery_unsupported', '' ),
+			array( null, '7.x', 'bfa_asset_delivery_unsupported', '' ),
+			array( array(), '7.x', 'bfa_asset_delivery_unsupported', '' ),
+			array( false, '7.x', 'bfa_asset_delivery_unsupported', '' ),
+			array( 'bundled-local', '5.x', 'bfa_asset_delivery_channel_unsupported', 'bundled-local' ),
+		);
+	}
+
+	public function test_first_caller_init_filter_can_select_local_delivery() {
+		add_filter( 'bfa_init_args', function ( $args ) { $args['asset_delivery'] = 'bundled-local'; return $args; } );
+		$library = Better_Font_Awesome_Library::get_instance();
+		$this->assertSame( 'bundled-local', $library->get_asset_delivery() );
+		$this->assertSame( $this->bundle(), $library->get_release_record() );
+		$this->assert_no_refresh_work();
+	}
+
+	/** @dataProvider bundle_failures */
+	public function test_broken_bundle_never_uses_remote_candidates( $path, $replacement ) {
+		$root = sys_get_temp_dir() . '/bfal-local-' . uniqid() . '/';
+		$bundle_root = $root . Better_Font_Awesome_Library::FONT_AWESOME_7_FALLBACK_PATH;
+		mkdir( $bundle_root . 'css', 0700, true );
+		mkdir( $bundle_root . 'webfonts', 0700, true );
+		$files = array_merge( array( 'metadata.json' ), array_column( $this->bundle()['release']['srisByLicense']['free'], 'path' ), array(
+			'webfonts/fa-brands-400.woff2', 'webfonts/fa-regular-400.woff2', 'webfonts/fa-solid-900.woff2', 'webfonts/fa-v4compatibility.woff2',
+		) );
+		try {
+			foreach ( $files as $file ) {
+				copy( dirname( __DIR__ ) . '/' . Better_Font_Awesome_Library::FONT_AWESOME_7_FALLBACK_PATH . $file, $bundle_root . $file );
+			}
+			if ( null === $replacement ) {
+				unlink( $bundle_root . $path );
+			} else {
+				file_put_contents( $bundle_root . $path, $replacement );
+			}
+			$GLOBALS['bfa_test_plugin_dir_path'] = $root;
+			$candidate = $this->candidate( 'newer' );
+			$GLOBALS['bfa_test_transients']['bfa-release-data'] = $candidate;
+			$library = Better_Font_Awesome_Library::get_instance( array(
+				'asset_delivery' => 'bundled-local', 'include_v4_shim' => true,
+				'release_data_provider' => function () use ( $candidate ) { $this->fail( 'Provider called for broken bundle.' ); return $candidate; },
+				'release_data_refresh_callback' => function () { $this->fail( 'Refresh requested for broken bundle.' ); },
+			) );
+			$this->assertInstanceOf( WP_Error::class, $library->get_error( 'fallback' ) );
+			if ( 'metadata.json' !== $path ) {
+				$this->assertSame( 'bfa_bundled_asset_unavailable', $library->get_error( 'fallback' )->get_error_code() );
+			}
+			$this->assertSame( 'bfa_refresh_disabled', $library->refresh_release_data()->get_error_code() );
+			$this->assert_closed( $library );
+			$this->assertSame( $candidate, $GLOBALS['bfa_test_transients']['bfa-release-data'] );
+		} finally {
+			$GLOBALS['bfa_test_plugin_dir_path'] = null;
+			foreach ( $files as $file ) {
+				if ( file_exists( $bundle_root . $file ) ) { unlink( $bundle_root . $file ); }
+			}
+			rmdir( $bundle_root . 'css' );
+			rmdir( $bundle_root . 'webfonts' );
+			rmdir( $bundle_root );
+			rmdir( $root . 'inc' );
+			rmdir( $root );
+		}
+	}
+
+	public static function bundle_failures() {
+		return array(
+			array( 'metadata.json', null ), array( 'metadata.json', '{invalid' ),
+			array( 'css/all.min.css', null ), array( 'css/v5-font-face.min.css', '' ),
+			array( 'css/v4-font-face.min.css', null ), array( 'css/v4-shims.min.css', null ),
+			array( 'webfonts/fa-brands-400.woff2', null ), array( 'webfonts/fa-regular-400.woff2', null ),
+			array( 'webfonts/fa-solid-900.woff2', null ), array( 'webfonts/fa-v4compatibility.woff2', null ),
+		);
+	}
+
+	private function bundle() {
+		return json_decode( file_get_contents( dirname( __DIR__ ) . '/inc/font-awesome-7-fallback/metadata.json' ), true );
+	}
+
+	private function candidate( $name ) {
+		if ( 'empty' === $name ) { return array(); }
+		if ( 'wrong-channel' === $name ) { return $this->get_valid_release(); }
+		if ( 'malformed' === $name ) { return array( 'version' => 'invalid' ); }
+		$record = $this->bundle();
+		if ( 'newer' === $name ) {
+			$record['release']['version'] = '7.99.0';
+			$record['release']['icons'] = array( $record['release']['icons'][0] );
+		}
+		return $record;
+	}
+
+	private function assert_closed( $library ) {
+		$this->assertSame( '', $library->get_version() );
+		$this->assertSame( '', $library->get_stylesheet_url() );
+		$this->assertSame( '', $library->get_stylesheet_url_v4_shim() );
+		$this->assertSame( array(), $library->get_release_record() );
+		$this->assertSame( array(), $library->get_release_icons() );
+		$this->assertSame( array(), $library->get_icons() );
+		$this->assertSame( array(), $library->get_release_assets() );
+		$library->register_font_awesome_css();
+		$library->register_v4_shim_inline_css();
+		$library->request_release_data_refresh();
+		$this->assertSame( array(), $GLOBALS['bfa_test_registered_styles'] );
+		$this->assertSame( array(), $GLOBALS['bfa_test_inline_styles'] );
+		$this->assertSame( array(), get_editor_stylesheets() );
+		$this->assertSame( array(), $GLOBALS['bfa_test_transient_reads'] );
+		$this->assertSame( array(), $GLOBALS['bfa_test_transient_writes'] );
+		$this->assert_no_refresh_work();
+	}
+
+	private function assert_no_refresh_work() {
+		$this->assertSame( 0, $GLOBALS['bfa_test_http_calls'] );
+		$this->assertNotContains( 'bfa_release_data_refresh_requested', array_column( $GLOBALS['bfa_test_did_actions'], 'tag' ) );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -118,6 +118,8 @@ function bfa_test_reset_wordpress_state() {
 	$GLOBALS['bfa_test_shortcodes']       = array();
 	$GLOBALS['bfa_test_transients']       = array();
 	$GLOBALS['bfa_test_transient_writes'] = array();
+	$GLOBALS['bfa_test_transient_reads']  = array();
+	$GLOBALS['bfa_test_plugin_dir_path']  = null;
 	$GLOBALS['bfa_test_set_transient_result'] = true;
 }
 
@@ -285,7 +287,7 @@ function plugin_dir_url( $file ) {
 }
 
 function plugin_dir_path( $file ) {
-	return dirname( $file ) . '/';
+	return $GLOBALS['bfa_test_plugin_dir_path'] ?? dirname( $file ) . '/';
 }
 
 function trailingslashit( $value ) {
@@ -305,6 +307,7 @@ function get_current_screen() {
 }
 
 function get_transient( $key ) {
+	$GLOBALS['bfa_test_transient_reads'][] = $key;
 	return array_key_exists( $key, $GLOBALS['bfa_test_transients'] )
 		? $GLOBALS['bfa_test_transients'][ $key ]
 		: false;


### PR DESCRIPTION
Adds optional local asset delivery for integrations that need to serve Font Awesome Free from the BFAL package. For example, with a newer FA7 provider record present, `asset_delivery => 'bundled-local'` immediately serves the packaged FA7 catalog, CSS, compatibility styles, and fonts. Omitting the argument preserves current automatic FA7 and explicit FA5 behavior.

Public contract:

- `get_instance( array( 'asset_delivery' => 'automatic' | 'bundled-local' ) )`; default is `automatic`. The existing initialization filters apply once to the immutable selection. First-caller channel and mode ownership remain unchanged.
- `get_asset_delivery()` returns the effective immutable mode, or `''` when the mode, channel, or mode/channel combination is unsupported; inspect `get_errors()` for configuration failures. Internal first-caller selection remains immutable. Bundle availability failures retain the valid `bundled-local` mode.
- Local mode bypasses provider invocation and transient reads/writes. `request_release_data_refresh()` does nothing, including on bundle failure. Explicit `refresh_release_data()` returns `WP_Error` code `bfa_refresh_disabled`, with zero HTTP/persistence, no record changes, and no admin diagnostic.
- Invalid mode: `get_error( 'delivery' )` code `bfa_asset_delivery_unsupported`. Explicit FA5/local: `bfa_asset_delivery_channel_unsupported`, with no channel switch. Both fail closed; explicit refresh returns the configuration error.
- Unavailable/invalid bundled metadata or missing, unreadable, or empty required assets fail closed with fallback diagnostics. No third-party fallback or refresh work. Missing asset code: `bfa_bundled_asset_unavailable`.

Repository guidance explicitly distinguishes automatic provider/transient precedence from the authorized bundled-local catalog pinning.

Reuses existing channel resolution, packaged metadata validation, asset routing, stylesheet handles, compatibility CSS, and editor integration. No ownership APIs, persistence, downloader, lifecycle, CORS, bundled asset, dependency, version, or BFA changes. New FA releases in local mode arrive through BFAL/embedding-plugin updates. Local delivery is FA7 Free only and does not control requests from other site components or URL-rewriting infrastructure.

Runtime validation on `0710440fe317986f33fbaac549d2ce31b75c4b08` (the subsequent `9b8fc57` commit changes only `AGENTS.md`; `git diff --check` passed) (base `a617fb562724ae5a97a6e308759b8235b60f87be`):

- Focused delivery tests: 31 tests, 461 assertions. Covers candidate precedence, unchanged catalog/picker, stylesheet/editor routing, zero HTTP/refresh work, explicit refresh, first-caller precedence, invalid configuration, and missing/empty bundle assets.
- Full PHPUnit suite on local PHP 8.5.10: 213 tests, 5,471 assertions, including existing FA5/FA7 compatibility and bundled CSS/font dependency tests.
- `composer check`, `composer validate --strict`, and `composer audit`: passed.
- `npm run build`: passed, with byte-identical tracked browser assets. `npm run audit:runtime-assets`: passed, zero shipped-asset vulnerabilities. `npm run verify:font-awesome-7-fallback`: passed, 13 files for FA Free 7.3.1.
- Production archive from the committed head: two byte-identical ZIPs, 35 production files, all bundled provenance hashes match, and development files excluded. SHA-256: `ed7598e917be73f2818b270fe45018bdd9f3c659e1f79bfc35243c56e71778cf`.
- Existing hosted PHP 7.4-8.4 and quality/packaging jobs passed for both [push](https://github.com/MickeyKay/better-font-awesome-library/actions/runs/34068218891) and [PR](https://github.com/MickeyKay/better-font-awesome-library/actions/runs/34068220594) on this head. GitGuardian passed. No BFA installation or broad WordPress browser matrix was run.

BFA handoff: pass the desired mode when BFA is the first caller, inspect `get_asset_delivery()` before scheduling, and treat `bfa_refresh_disabled` as a disabled operation without retries. Preserve stored remote metadata for future automatic-mode requests. A later BFA caller cannot override an earlier consumer's mode or channel.

Existing issue outside this feature: the unchanged root development dependency tree reports three high-severity npm audit findings in Lodash and its Grunt logging dependents. These packages are excluded from production archives; the shipped runtime audit is clean. Dependency remediation is left separate to keep this PR focused.


