### PR TITLE
Prepare BFAL 3.1.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 3.1.0
+
+- Add optional `asset_delivery => 'bundled-local'` for Font Awesome 7 Free. The active version, icon catalog, picker data, CSS, compatibility styles, and WOFF2 fonts all use the same packaged Font Awesome Free 7.3.1 release.
+- In local mode, bypass providers and transients without reading or mutating them, request no background refresh, and perform no remote refresh. Missing or invalid bundled files fail closed without substituting remote assets. New icons arrive through BFAL or embedding-plugin updates.
+- Keep `automatic` as the default, with validated provider or transient metadata ahead of the bundled fallback and consumer-managed asynchronous updates within the selected channel. Ordinary requests continue to perform no metadata HTTP.
+- Preserve first-caller ownership of all initialization arguments, including delivery mode and channel. Later callers cannot change the instance; hook priority remains the ownership mechanism.
+- Reject explicit FA5 with local delivery without switching channels. FA5 remains supported in automatic mode.
+- Promote the reviewed bundled-local implementation without runtime changes beyond the BFAL version constant and resulting stylesheet and script cache keys, now `3.1.0`. Bundled metadata, CSS, fonts, licenses, and provenance remain unchanged.
+
 ## 3.0.2
 
 - Treat a fully validated Font Awesome 5 release in the shared legacy transient as an incompatible cache miss when the immutable 7.x channel is selected, without diagnostics or transient mutation.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The Better Font Awesome Library integrates validated Font Awesome Free metadata 
 ## Installation ##
 The Better Font Awesome Library should ideally be installed via Composer:
 ```
-composer require mickey-kay/better-font-awesome-library:3.0.2
+composer require mickey-kay/better-font-awesome-library:"^3.1"
 ```
 
 Alternately, you can install the library manually, which can be useful for development and/or custom builds:
@@ -49,15 +49,15 @@ npm run build
 
 ## Stable release and rollback ##
 
-BFAL 3.0.2 is the stable release. Composer users can install it with:
+Composer users can select the stable BFAL 3 line with optional local delivery after its tag is published:
 
 ```
-composer require mickey-kay/better-font-awesome-library:3.0.2
+composer require mickey-kay/better-font-awesome-library:"^3.1"
 ```
 
-BFAL 3.0.2 defaults to Font Awesome 7 and preserves explicit Font Awesome 5 selection. Ordinary requests perform no metadata or candidate-validation HTTP. BFAL provides validated local metadata, packaged fallback assets, and explicit asynchronous refresh operations while consumers continue to own WordPress persistence, scheduling, locking, retry, freshness, and migration policy.
+BFAL 3 defaults to Font Awesome 7 and preserves explicit Font Awesome 5 selection. Automatic delivery remains the default, with validated provider or transient metadata taking precedence over the bundled fallback. Ordinary requests perform no metadata or candidate-validation HTTP. BFAL provides validated local metadata, packaged fallback assets, and explicit asynchronous refresh operations while consumers continue to own WordPress persistence, scheduling, locking, retry, freshness, and migration policy.
 
-The corrective release treats a fully validated Font Awesome 5 value in the shared legacy transient as an incompatible cache miss when the 7.x channel is selected. It adds no diagnostic, does not mutate the transient, continues to the unchanged packaged Font Awesome Free 7.3.1 fallback, and requests asynchronous refresh once. The BFAL 3.0.1 empty-provider correction remains intact, and WordPress uses `?ver=3.0.2` for BFAL stylesheet and script cache keys.
+Optional [bundled-local delivery](#local-asset-delivery) pins the active FA7 Free catalog, CSS, compatibility styles, and fonts to the same packaged release, with no remote refresh. New icons arrive through library or embedding-plugin updates. The first caller owns the mode and channel; explicit FA5 with local delivery fails closed without switching channels.
 
 To roll back to the Font Awesome 5 stable line, restore BFAL 2.1.0 and redeploy the resulting lockfile:
 
@@ -65,7 +65,7 @@ To roll back to the Font Awesome 5 stable line, restore BFAL 2.1.0 and redeploy 
 composer require mickey-kay/better-font-awesome-library:2.1.0 --with-all-dependencies
 ```
 
-BFAL follows versions published from repository tags. BFAL 3.0.2 preserves the first-caller singleton ownership contract, channels, metadata transport, validation, caching, fallback, refresh, routing, public APIs, precedence, and ownership behavior established in 3.0.0.
+BFAL follows versions published from repository tags. See [CHANGELOG.md](CHANGELOG.md) for release history. WordPress stylesheet and script cache keys use the installed BFAL version.
 
 ## Font Awesome 7 and BFAL 3 ##
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,6 +22,8 @@ Run the generation command a second time and require an empty diff to verify byt
 
 ## Prepare and verify
 
+Before editing, fetch current master and tags, verify the required reviewed feature commit and tree, and check GitHub releases and Packagist for the proposed version. Report any intervening changes before including them. Never overwrite an existing version.
+
 Set the intended BFAL version and start from a clean checkout of its candidate commit:
 
 ```console
@@ -37,14 +39,19 @@ npm run verify:font-awesome-7-fallback
 git diff --exit-code
 ```
 
-Confirm that `Better_Font_Awesome_Library::VERSION`, both npm manifests, both npm lockfile root records, the compatibility test, and the changelog use the intended release version. `composer.json` intentionally has no version field because Composer derives the package version from the tag.
+Confirm that `Better_Font_Awesome_Library::VERSION`, both npm manifests, both npm lockfile root records, the compatibility test and its stylesheet/script cache-key assertions, and the changelog use the intended release version. `composer.json` intentionally has no version field because Composer derives the package version from the tag.
+
+For a version-only promotion, compare the candidate against the reviewed feature tree. After normalizing only the BFAL version constant, runtime implementation must be byte-identical. Confirm bundled metadata, CSS, fonts, licenses, and provenance are unchanged. Reuse existing consumer integration evidence, recording its exact tested commit and any later head separately; do not repeat the full consumer browser or WordPress matrix unless a behavior change or evidence gap requires it.
 
 ## Build the production archive
 
-Record the reviewed production file count in the release-preparation evidence, then create two verification archives only from the unpushed local tag. The tracked `.gitattributes` rules exclude tests, agent files, development configuration, development locks, build sources, and release tooling. Runtime Composer dependencies belong in `composer.json`. If BFAL has no runtime Composer dependencies, the archive must not contain `vendor`.
+During release preparation, build two provisional archives from the exact committed candidate SHA without creating a tag. Record the candidate commit and tree, reviewed production file count, byte comparison, inventory, size, and SHA-256 in the draft release-preparation PR. Candidate archives are verification evidence, not publication artifacts. After approval and merge, rebuild and reverify from the exact unpushed local release tag before publication; the final archive identity can differ because Git archives include commit identity and timestamps.
+
+Set `ARCHIVE_REF` to the candidate SHA for provisional verification, or to the unpushed local tag for final publication verification. The tracked `.gitattributes` rules exclude tests, agent files, development configuration, development locks, build sources, and release tooling. Runtime Composer dependencies belong in `composer.json`. If BFAL has no runtime Composer dependencies, the archive must not contain `vendor`.
 
 ```console
 RELEASE_VERSION="<version>"
+ARCHIVE_REF="<candidate commit SHA or unpushed local release tag>"
 EXPECTED_FILE_COUNT="<reviewed production file count>"
 ARTIFACT_PATH="better-font-awesome-library-${RELEASE_VERSION}.zip"
 VERIFICATION_ARTIFACT_PATH="better-font-awesome-library-${RELEASE_VERSION}-verification.zip"
@@ -53,12 +60,12 @@ git archive \
   --format=zip \
   --prefix="better-font-awesome-library-${RELEASE_VERSION}/" \
   --output="$ARTIFACT_PATH" \
-  "$RELEASE_VERSION"
+  "$ARCHIVE_REF"
 git archive \
   --format=zip \
   --prefix="better-font-awesome-library-${RELEASE_VERSION}/" \
   --output="$VERIFICATION_ARTIFACT_PATH" \
-  "$RELEASE_VERSION"
+  "$ARCHIVE_REF"
 cmp "$ARTIFACT_PATH" "$VERIFICATION_ARTIFACT_PATH"
 shasum -a 256 "$ARTIFACT_PATH" > "$CHECKSUM_PATH"
 ARCHIVE_FILE_COUNT="$(unzip -Z1 "$ARTIFACT_PATH" | awk '! /\/$/ { count++ } END { print count + 0 }')"
@@ -67,7 +74,7 @@ cat "$CHECKSUM_PATH"
 unzip -l "$ARTIFACT_PATH"
 ```
 
-The two archives must be byte-identical. Before publication, manually confirm the reviewed file count, the single exact versioned root directory, every required runtime file, all version surfaces, and the final SHA-256 checksum. Confirm tests, agent files, development dependencies, build sources, `node_modules`, and any excluded `vendor` directory are absent.
+The two archives must have identical inventories and be byte-identical. Before publication, manually confirm the reviewed file count, the single exact versioned root directory, every required runtime file, all version surfaces, and the final SHA-256 checksum. Confirm tests, agent files, development dependencies, build sources, `node_modules`, and any excluded `vendor` directory are absent.
 
 ## Publish
 

--- a/better-font-awesome-library.php
+++ b/better-font-awesome-library.php
@@ -51,7 +51,7 @@ class Better_Font_Awesome_Library {
 	 *
 	 * @var    string
 	 */
-	const VERSION = '3.0.2';
+	const VERSION = '3.1.0';
 
 	/**
 	 * Font awesome GraphQL url.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-font-awesome-library",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-font-awesome-library",
-      "version": "3.0.2",
+      "version": "3.1.0",
       "license": "GPL-2.0",
       "devDependencies": {
         "fontawesome-iconpicker": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-font-awesome-library",
   "description": "Better Font Awesome Library",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "main": " ",
   "devDependencies": {
     "fontawesome-iconpicker": "3.2.0",

--- a/runtime-assets/package-lock.json
+++ b/runtime-assets/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-font-awesome-library-runtime-assets",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-font-awesome-library-runtime-assets",
-      "version": "3.0.2",
+      "version": "3.1.0",
       "dependencies": {
         "fontawesome-iconpicker": "3.2.0"
       }

--- a/runtime-assets/package.json
+++ b/runtime-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-font-awesome-library-runtime-assets",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "private": true,
   "description": "Audit manifest for third-party browser source copied into BFAL release archives.",
   "dependencies": {

--- a/tests/PublicCompatibilityTest.php
+++ b/tests/PublicCompatibilityTest.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/BfalTestCase.php';
 class PublicCompatibilityTest extends BfalTestCase {
 	public function test_public_constants_are_preserved() {
 		$this->assertSame( 'bfa', Better_Font_Awesome_Library::SLUG );
-		$this->assertSame( '3.0.2', Better_Font_Awesome_Library::VERSION );
+		$this->assertSame( '3.1.0', Better_Font_Awesome_Library::VERSION );
 		$this->assertSame( 'https://api.fontawesome.com', Better_Font_Awesome_Library::FONT_AWESOME_API_BASE_URL );
 		$this->assertSame( 'https://use.fontawesome.com/releases', Better_Font_Awesome_Library::FONT_AWESOME_CDN_BASE_URL );
 		$this->assertSame( 'inc/fallback-release-data.json', Better_Font_Awesome_Library::FALLBACK_RELEASE_DATA_PATH );
@@ -208,8 +208,8 @@ class PublicCompatibilityTest extends BfalTestCase {
 
 		$this->assertArrayHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_registered_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_registered_styles'] );
-		$this->assertSame( '3.0.2', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome']['version'] );
-		$this->assertSame( '3.0.2', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome-v4-shim']['version'] );
+		$this->assertSame( '3.1.0', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome']['version'] );
+		$this->assertSame( '3.1.0', $GLOBALS['bfa_test_registered_styles']['bfa-font-awesome-v4-shim']['version'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome', $GLOBALS['bfa_test_enqueued_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_enqueued_styles'] );
 		$this->assertArrayHasKey( 'bfa-font-awesome-v4-shim', $GLOBALS['bfa_test_inline_styles'] );
@@ -219,10 +219,10 @@ class PublicCompatibilityTest extends BfalTestCase {
 	public function test_admin_asset_cache_keys_use_the_release_version() {
 		$this->get_instance()->enqueue_admin_scripts();
 
-		$this->assertSame( '3.0.2', $GLOBALS['bfa_test_enqueued_styles']['bfa-admin']['version'] );
-		$this->assertSame( '3.0.2', $GLOBALS['bfa_test_enqueued_styles']['fontawesome-iconpicker']['version'] );
-		$this->assertSame( '3.0.2', $GLOBALS['bfa_test_enqueued_scripts']['bfa-admin']['version'] );
-		$this->assertSame( '3.0.2', $GLOBALS['bfa_test_enqueued_scripts']['fontawesome-iconpicker']['version'] );
+		$this->assertSame( '3.1.0', $GLOBALS['bfa_test_enqueued_styles']['bfa-admin']['version'] );
+		$this->assertSame( '3.1.0', $GLOBALS['bfa_test_enqueued_styles']['fontawesome-iconpicker']['version'] );
+		$this->assertSame( '3.1.0', $GLOBALS['bfa_test_enqueued_scripts']['bfa-admin']['version'] );
+		$this->assertSame( '3.1.0', $GLOBALS['bfa_test_enqueued_scripts']['fontawesome-iconpicker']['version'] );
 	}
 
 	public function test_documented_initialization_and_notice_filters_remain_active() {


### PR DESCRIPTION
Prepares **BFAL 3.1.0** as the stable release of merged #52's optional bundled-local FA7 Free delivery. Automatic delivery remains the default. This promotion changes no runtime behavior beyond the BFAL version constant and resulting stylesheet/script cache keys.

## Release identity and scope

- Proposed version: `3.1.0`, an additive minor release. Before editing, refreshed master/tags and checked GitHub releases and Packagist: latest stable was `3.0.2` at `a617fb562724ae5a97a6e308759b8235b60f87be`; neither numeric nor v-prefixed `3.1.0` existed. No existing version is overwritten.
- Base and required feature merge: `7bd53f548fe5028e0f60a35c6b457c05356ec811`.
- Starting tree: `86fb39e848baff1cc449e9bb86d5380e8a9d2bbd`, exactly the required reviewed feature tree and merged #52 head's tree. No intervening BFAL changes. Remote master was checked again after the commit and remains at this base.
- Candidate commit: `13983ad206d4b9a11dbde0dc37326e14231fe669`.
- Candidate tree: `ec08cb97de7efe6eb13fc6d570cc69e3cf918d03`.
- Branch: `prepare-bfal-3-1-0-release`.
- Exactly nine files changed: `better-font-awesome-library.php`; both `package.json` files; both `package-lock.json` files; `tests/PublicCompatibilityTest.php`; `CHANGELOG.md`; `README.md`; `RELEASING.md`.
- All seven version values across the runtime constant, npm manifests, and lockfile root records agree at `3.1.0`. All seven compatibility/version/cache-key assertions agree. Composer remains versionless; all dependency records are unchanged.

The changelog and README describe the matching bundled catalog, CSS, compatibility styles, and fonts; no remote refresh in local mode; icon updates through BFAL or embedding-plugin updates; automatic mode remaining the default; first-caller ownership; and explicit FA5/local rejection without channel switching. README installation uses the compatible `^3.1` stable line. Reusable release documentation stays parameterized and distinguishes provisional commit archives from final post-merge local-tag verification.

## Runtime-equivalence proof

Compared candidate and feature production archives using the same root. Their inventories are identical. Of 35 production files, 32 are byte-identical. Only `CHANGELOG.md`, `README.md`, and `better-font-awesome-library.php` differ. Replacing only `const VERSION = '3.1.0';` with its reviewed `3.0.2` value makes the runtime PHP file byte-identical to the feature merge.

All other PHP implementation, browser JS/CSS, legacy fallback metadata/checksum, bundled FA7 metadata/CSS/WOFF2 fonts, licenses, attribution, provenance, Composer files, and export rules are unchanged. The FA7 verifier passes all 13 packaged files for Font Awesome Free 7.3.1, including the 11 provenance-hashed payloads. No metadata or asset regeneration was performed.

## Validation

Local environment: PHP 8.5.10, Composer 2.10.3, Node 24.14.1, npm 11.11.0.

- `composer install --no-interaction --prefer-dist`: pass.
- `composer validate --strict`: pass; `composer audit`: no advisories.
- Release identity and compatibility: `vendor/bin/phpunit --filter PublicCompatibilityTest`, 10 tests / 133 assertions, pass.
- `composer check`: 213 tests / 5,471 assertions, PHPCS and PHPStan all pass.
- `npm run build`: pass; rebuilt tracked assets are byte-identical.
- `npm run audit:runtime-assets`: source coverage verified; zero shipped-asset vulnerabilities.
- `npm run verify:font-awesome-7-fallback`: pass, 13 files.
- Version/dependency structural comparison, whitespace check, unchanged asset/license/provenance comparison, and clean tracked checkout after commit: pass.
- The build's broader development dependency audit reports three high-severity entries in the unchanged lodash / grunt-legacy-log / grunt-legacy-log-utils chain. Development dependencies and locks are excluded from the production archive. No dependency updates are included in this version-only promotion.

Hosted BFAL CI passes all seven jobs (PHP 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, and quality/packaging) in both the [candidate push run](https://github.com/MickeyKay/better-font-awesome-library/actions/runs/34163079964) and [pull request run](https://github.com/MickeyKay/better-font-awesome-library/actions/runs/34163082686). Publication still requires the complete matrix on the final merged commit.

## Existing BFA integration evidence

Reuse [BFA PR #64](https://github.com/MickeyKay/better-font-awesome/pull/64), without modifying BFA or recreating its browser/WordPress matrix.

- Final independently reviewed BFA head, confirmed by the owner: `9a70d8310f9316350c28d1e8253ef7bc3ca21b9f`, with no actionable P0-P3 findings. This supersedes the earlier supplied `270826e9d41cf0597de67132bf6491a65f5d2212` review identity.
- The supplied final review verified local asset rendering, zero attempted third-party requests, settings persistence, mode switching, ownership, multisite, and cancellation/lease regressions. All hosted checks passed. This existing evidence is reused; no BFA implementation changes or repeated BFA matrix are included here.
- Owner manual QA is still pending and is not represented as completed.
- The current PR still pins BFAL to `dev-master#7bd53f548fe5028e0f60a35c6b457c05356ec811`. [All 10 CI jobs pass on its current head](https://github.com/MickeyKay/better-font-awesome/actions/runs/34155870315), covering quality, four pinned-BFAL compatibility jobs, two rollback jobs, two browser jobs, and Plugin Check.
- BFA owner manual QA and acceptance, adoption of the published stable BFAL dependency, restored passing strict Composer validation, and consumer release/package checks remain BFA release gates.

## Provisional artifact evidence

Built twice with `git archive --format=zip` from the exact candidate commit above, without creating any tag.

| Field | Verified value |
| --- | --- |
| Archive | `better-font-awesome-library-3.1.0.zip` |
| Verification archive | `better-font-awesome-library-3.1.0-verification.zip` |
| Single root | `better-font-awesome-library-3.1.0/` |
| Production files | 35 |
| Bytes per ZIP | 462639 |
| SHA-256 of each ZIP | `9aa5d900575841a75de39225db029a268ebd218bbd4bfab51028a11836149522` |
| Inventory and byte comparison | Identical; ZIP CRC checks pass |

Audited the exact 35-file allowlist: runtime entrypoint, five supporting PHP classes, Composer manifest, README/changelog, library and third-party notices/licenses, legacy fallback and checksum, all 13 FA7 bundle files, four admin JS/CSS files, and five iconpicker distribution/license files. Every extracted file matches both the candidate Git blob and working-tree bytes. No duplicate entries, unsafe paths, or unexpected roots.

Excluded tests/fixtures, agent files, `.context`, Git/GitHub configuration, PHP tooling configuration, `composer.lock`, Node manifests/locks, `runtime-assets`, `scripts`, `Gruntfile.js`, `RELEASING.md`, `node_modules`, and `vendor`. Composer has no runtime dependencies.

Local evidence is retained under `.context/release-3.1.0/`: both candidate ZIPs, checksum file, exact inventory, per-file SHA-256 manifest, artifact audit script/JSON, dependency audits, test/check logs, Packagist response, and BFA evidence snapshot. These provisional artifacts are not published release assets.

## Remaining publication gates

1. Approve and merge this draft preparation PR, then confirm the complete hosted PHP 7.4-8.4 and quality/packaging matrix on the exact final merged commit.
2. Recheck version availability; create the numeric lightweight tag locally on that approved merge only under publication authorization.
3. Build twice from the unpushed local tag and repeat identity, inventory, exclusions, byte, and checksum verification. Record the final artifact identity, which can differ from this provisional commit archive.
4. Under separate publication authorization, push the verified tag, create the GitHub release with ZIP/checksum and matching release-note hash, and verify Packagist's exact commit and distribution contents.
5. Complete BFA's stable dependency adoption and its remaining consumer acceptance gates separately.

This PR does not merge, tag, publish, update Packagist, or modify BFA.
